### PR TITLE
ci: drop @semantic-release/git so releases work under branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,6 @@ jobs:
         run: |
           npm install -g \
             semantic-release@24 \
-            @semantic-release/changelog@6 \
-            @semantic-release/git@10 \
             @semantic-release/github@11
 
       - name: Determine version
@@ -145,13 +143,7 @@ jobs:
         run: |
           npm install -g \
             semantic-release@24 \
-            @semantic-release/changelog@6 \
-            @semantic-release/git@10 \
             @semantic-release/github@11
-
-      - name: Replace project.pbxproj
-        run: |
-          cp -f artifacts/project.pbxproj "Blue Switch.xcodeproj/project.pbxproj"
 
       - name: Release
         env:

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -4,14 +4,6 @@
     [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
-      "@semantic-release/changelog",
-      [
-        "@semantic-release/git",
-        {
-          "assets": ["Blue Switch.xcodeproj/project.pbxproj", "CHANGELOG.md"],
-          "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
-        },
-      ],
       [
         "@semantic-release/github",
         {


### PR DESCRIPTION
The git plugin pushes a `chore(release): X.Y.Z [skip ci]` commit back to `main`, which fails when the branch is protected. Tags and GitHub Releases are still created by `@semantic-release/github` via the API, which is not subject to branch-push protection.

Trade-offs:
- CHANGELOG.md is no longer maintained in the repo (release notes still live on each GitHub Release page).
- MARKETING_VERSION in the pbxproj stays static. The build pipeline rewrites it via sed before xcodebuild, so the shipped .app has the correct version regardless.

Also dropped:
- @semantic-release/changelog (would write CHANGELOG.md that never gets persisted) from both npm install steps.
- The release job's `cp artifacts/project.pbxproj` step, which only existed so the git plugin had the version-bumped pbxproj to commit.