### PR TITLE
ci: add workflow_dispatch trigger to Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: release-${{ github.ref }}


### PR DESCRIPTION
Allows manual re-runs from the Actions UI or via gh workflow run, so a suppressed push event (eg a commit message accidentally containing a GitHub-recognised skip token) doesn't strand the release pipeline.