### PR TITLE
Audit fixes and polish

### DIFF
--- a/Blue Switch/AppDelegate/AppDelegate.swift
+++ b/Blue Switch/AppDelegate/AppDelegate.swift
@@ -15,6 +15,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   private var statusItem: NSStatusItem!
   private var settingsWindowController: NSWindowController?
   private var bluetoothStateObserver: AnyCancellable?
+  private var pairingObserver: AnyCancellable?
   private var lastBluetoothState: CBManagerState = .unknown
 
   // MARK: - Constants
@@ -40,6 +41,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       .receive(on: DispatchQueue.main)
       .sink { [weak self] state in
         self?.handleBluetoothStateChange(state)
+        self?.refreshStatusBarIcon()
+      }
+    pairingObserver = PairingStore.shared.$isPaired
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] _ in
+        self?.refreshStatusBarIcon()
       }
     BluetoothManager.shared.setup()
   }
@@ -79,17 +86,60 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     guard let button = statusItem.button else { return }
 
     configureStatusBarButton(button)
+    refreshStatusBarIcon()
   }
 
   private func configureStatusBarButton(_ button: NSStatusBarButton) {
-    if let customImage = NSImage(named: "StatusBarIcon") {
-      customImage.size = NSSize(width: 24, height: 24)
-      customImage.isTemplate = true
-      button.image = customImage
-    }
     button.target = self
     button.action = #selector(handleClick(_:))
     button.sendAction(on: [.leftMouseUp, .rightMouseUp])
+  }
+
+  /// Updates the menu-bar icon based on the combined Pairing + Bluetooth
+  /// state. When the app cannot function (unpaired, Bluetooth off, etc.) we
+  /// show a triangle exclamation mark instead of the regular icon so the
+  /// user can tell at a glance.
+  private func refreshStatusBarIcon() {
+    guard let button = statusItem?.button else { return }
+    let needsAttention =
+      !PairingStore.shared.isPaired
+      || (BluetoothManager.shared.state != .poweredOn
+        && BluetoothManager.shared.state != .unknown)
+
+    if needsAttention {
+      let image = NSImage(
+        systemSymbolName: "exclamationmark.triangle.fill",
+        accessibilityDescription: "Blue Switch needs attention")
+      image?.isTemplate = true
+      button.image = image
+      button.toolTip = statusBarTooltip()
+    } else if let normal = NSImage(named: "StatusBarIcon") {
+      normal.size = NSSize(width: 24, height: 24)
+      normal.isTemplate = true
+      button.image = normal
+      button.toolTip = "Blue Switch"
+    }
+    button.setAccessibilityLabel(statusBarTooltip())
+  }
+
+  private func statusBarTooltip() -> String {
+    if !PairingStore.shared.isPaired {
+      return "Blue Switch: not paired. Open Settings → Pairing."
+    }
+    switch BluetoothManager.shared.state {
+    case .poweredOff:
+      return "Blue Switch: Bluetooth is off."
+    case .unauthorized:
+      return "Blue Switch: Bluetooth permission denied."
+    case .unsupported:
+      return "Blue Switch: Bluetooth not supported on this Mac."
+    case .resetting:
+      return "Blue Switch: Bluetooth is resetting."
+    case .poweredOn, .unknown:
+      return "Blue Switch"
+    @unknown default:
+      return "Blue Switch"
+    }
   }
 
   // MARK: - Action Handlers
@@ -190,9 +240,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       }
     case .partial:
       NotificationManager.showNotification(
-        title: "Mixed State",
+        title: "Peripherals in mixed state",
         body:
-          "Some peripherals are connected and others aren't. Connect or disconnect them all before switching.",
+          "Some peripherals are connected to this Mac and others aren't. Open Settings → Peripheral and either connect or remove each one so they're all in the same state, then click the menu bar icon again.",
         identifier: "switch-mixed-state"
       )
     }

--- a/Blue Switch/AppDelegate/AppDelegate.swift
+++ b/Blue Switch/AppDelegate/AppDelegate.swift
@@ -155,40 +155,45 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       waitForDisconnection { [weak self] allDisconnected in
         guard let self = self else { return }
         if allDisconnected {
-          self.networkStore.executeCommand(.connectAll) { success in
-            if !success {
+          self.networkStore.executeCommand(.connectAll) { result in
+            if case .failure(let err) = result {
               NotificationManager.showNotification(
-                title: "Error",
-                body: "Connection process failed on target device"
+                title: "Switch Failed",
+                body: err.userMessage,
+                identifier: "switch-connect-failed"
               )
             }
           }
         } else {
           NotificationManager.showNotification(
-            title: "Error",
-            body: "Failed to disconnect devices"
+            title: "Switch Failed",
+            body: "Couldn't disconnect Bluetooth peripherals from this Mac.",
+            identifier: "switch-disconnect-local-failed"
           )
         }
       }
     case .allDisconnected:
-      networkStore.executeCommand(.unregisterAll) { [weak self] success in
+      networkStore.executeCommand(.unregisterAll) { [weak self] result in
         guard let self = self else { return }
-        if success {
+        switch result {
+        case .success:
           self.bluetoothStore.peripherals.forEach { peripheral in
             self.bluetoothStore.connectPeripheral(peripheral)
           }
-        } else {
+        case .failure(let err):
           NotificationManager.showNotification(
-            title: "Error",
-            body: "Failed to request device disconnection from peer"
+            title: "Switch Failed",
+            body: err.userMessage,
+            identifier: "switch-disconnect-remote-failed"
           )
         }
       }
     case .partial:
       NotificationManager.showNotification(
-        title: "Warning",
+        title: "Mixed State",
         body:
-          "Some devices are connected while others are disconnected. Please ensure all devices are in the same state."
+          "Some peripherals are connected and others aren't. Connect or disconnect them all before switching.",
+        identifier: "switch-mixed-state"
       )
     }
   }

--- a/Blue Switch/Manager/NotificationManager.swift
+++ b/Blue Switch/Manager/NotificationManager.swift
@@ -12,7 +12,10 @@ protocol NotificationManaging {
   /// - Parameters:
   ///   - title: The notification title
   ///   - body: The notification message
-  static func showNotification(title: String, body: String)
+  ///   - identifier: Optional stable identifier. Re-posting with the same
+  ///     identifier replaces the previous notification rather than stacking,
+  ///     so rapid retries coalesce instead of flooding Notification Centre.
+  static func showNotification(title: String, body: String, identifier: String?)
 }
 
 final class NotificationManager: NotificationManaging {
@@ -51,10 +54,10 @@ final class NotificationManager: NotificationManaging {
     }
   }
 
-  static func showNotification(title: String, body: String) {
+  static func showNotification(title: String, body: String, identifier: String? = nil) {
     let content = createNotificationContent(title: title, body: body)
     let request = UNNotificationRequest(
-      identifier: UUID().uuidString,
+      identifier: identifier ?? UUID().uuidString,
       content: content,
       trigger: nil
     )

--- a/Blue Switch/Manager/OutgoingConnection.swift
+++ b/Blue Switch/Manager/OutgoingConnection.swift
@@ -1,6 +1,39 @@
 import Foundation
 import Network
 
+/// Categorised outgoing-side failure. Carries enough information for the
+/// caller to render a useful user-facing notification without needing to
+/// know about `SecureChannel` internals.
+enum OutgoingFailure: Error {
+  case notPaired
+  case connectionFailed(String)
+  case connectTimeout
+  case handshakeFailed(SecureChannelError)
+  case bodyFailed
+
+  /// Short, user-facing reason. Callers prepend the device name.
+  var userMessage: String {
+    switch self {
+    case .notPaired:
+      return "This Mac isn't paired yet. Open the Pairing tab in Settings."
+    case .connectionFailed:
+      return "Couldn't reach the other Mac on the network."
+    case .connectTimeout:
+      return "The other Mac didn't respond in time."
+    case .handshakeFailed(.authFailed):
+      return "Pairing codes don't match. Re-pair both Macs with the same code."
+    case .handshakeFailed(.handshakeTimeout):
+      return "The other Mac didn't respond to the secure handshake."
+    case .handshakeFailed(.replay), .handshakeFailed(.decryptionFailed):
+      return "Couldn't establish a secure connection (possible tampering)."
+    case .handshakeFailed:
+      return "Couldn't establish a secure connection."
+    case .bodyFailed:
+      return "The connection dropped mid-message."
+    }
+  }
+}
+
 /// Single-shot authenticated client connection to a peer Blue Switch instance.
 /// Owns its NWConnection + SecureChannel; tears itself down once `run` is
 /// complete (success or failure).
@@ -39,16 +72,18 @@ final class OutgoingConnection {
   // MARK: - Public API
 
   /// Runs the handshake then invokes `body` with the live secure channel.
-  /// `body` must call `done(_:)` to release the connection.
+  /// `body` must call `done(_:)` to release the connection. The completion
+  /// receives a `Result` whose failure case carries a categorised reason
+  /// (see `OutgoingFailure`) so the caller can render a useful notification.
   func run(
     body: @escaping (SecureChannel, @escaping (Bool) -> Void) -> Void,
-    completion: @escaping (Bool) -> Void
+    completion: @escaping (Result<Void, OutgoingFailure>) -> Void
   ) {
     selfRef = self
 
     guard let psk = pairingStore.currentKey() else {
       print("OutgoingConnection: not paired, aborting send")
-      completion(false)
+      completion(.failure(.notPaired))
       release()
       return
     }
@@ -62,7 +97,7 @@ final class OutgoingConnection {
     timer.schedule(deadline: .now() + Self.connectionTimeout)
     timer.setEventHandler { [weak self] in
       guard let self = self else { return }
-      self.finish(success: false, completion: completion)
+      self.finish(.failure(.connectTimeout), completion: completion)
     }
     timer.resume()
     connectTimer = timer
@@ -77,16 +112,19 @@ final class OutgoingConnection {
             self.connectTimer?.cancel()
             self.connectTimer = nil
             body(channel) { ok in
-              self.finish(success: ok, completion: completion)
+              self.finish(
+                ok ? .success(()) : .failure(.bodyFailed), completion: completion)
             }
           case .failure(let err):
             print("OutgoingConnection handshake failed: \(err)")
-            self.finish(success: false, completion: completion)
+            self.finish(.failure(.handshakeFailed(err)), completion: completion)
           }
         }
       case .failed(let error):
         print("OutgoingConnection failed: \(error)")
-        self.finish(success: false, completion: completion)
+        self.finish(
+          .failure(.connectionFailed(error.localizedDescription)),
+          completion: completion)
       case .cancelled:
         // No-op; finish handled explicitly.
         break
@@ -99,14 +137,17 @@ final class OutgoingConnection {
 
   // MARK: - Helpers
 
-  private func finish(success: Bool, completion: @escaping (Bool) -> Void) {
+  private func finish(
+    _ result: Result<Void, OutgoingFailure>,
+    completion: @escaping (Result<Void, OutgoingFailure>) -> Void
+  ) {
     guard !finished else { return }
     finished = true
     connectTimer?.cancel()
     connectTimer = nil
     channel?.cancel()
     connection.cancel()
-    completion(success)
+    completion(result)
     release()
   }
 

--- a/Blue Switch/Manager/PairingStore.swift
+++ b/Blue Switch/Manager/PairingStore.swift
@@ -82,12 +82,33 @@ final class PairingStore: ObservableObject {
   }
 
   /// Derives K from a pairing code and stores it in the keychain.
-  func pair(withCode code: String) throws {
-    let normalized = Self.normalize(code)
-    guard Self.isValid(normalized) else { throw PairingError.invalidCode }
-    let key = try Self.deriveKey(fromCode: normalized)
-    try writeKeyData(key)
-    refreshState()
+  /// Runs the PBKDF2 derivation off-main (600k iterations is ~half a second)
+  /// and reports back on main. The published state is updated before the
+  /// completion fires.
+  func pair(
+    withCode code: String,
+    completion: @escaping (Result<Void, PairingError>) -> Void
+  ) {
+    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+      guard let self = self else { return }
+      let normalized = Self.normalize(code)
+      guard Self.isValid(normalized) else {
+        DispatchQueue.main.async { completion(.failure(.invalidCode)) }
+        return
+      }
+      do {
+        let key = try Self.deriveKey(fromCode: normalized)
+        try self.writeKeyData(key)
+        DispatchQueue.main.async {
+          self.refreshState()
+          completion(.success(()))
+        }
+      } catch let error as PairingError {
+        DispatchQueue.main.async { completion(.failure(error)) }
+      } catch {
+        DispatchQueue.main.async { completion(.failure(.derivationFailed)) }
+      }
+    }
   }
 
   /// Removes the stored PSK.

--- a/Blue Switch/Manager/ServiceBrowser.swift
+++ b/Blue Switch/Manager/ServiceBrowser.swift
@@ -35,6 +35,14 @@ final class ServiceBrowser: NSObject, ServiceBrowsing {
     serviceBrowser?.stop()
     services.removeAll()
   }
+
+  /// Tear down and re-start browsing. Used by the manual "refresh" affordance
+  /// when Bonjour gets confused (network switch, wake from sleep) and the
+  /// in-memory list goes stale.
+  func refresh() {
+    stopBrowsing()
+    startBrowsing()
+  }
 }
 
 // MARK: - NetServiceBrowserDelegate

--- a/Blue Switch/Model/Entity/NetworkDevice.swift
+++ b/Blue Switch/Model/Entity/NetworkDevice.swift
@@ -28,6 +28,11 @@ struct NetworkDevice: Identifiable, Codable {
   /// impersonation attempts and the routing info is not updated.
   var fingerprint: String?
 
+  /// When a peer advertises a fingerprint that does not match the stored
+  /// pin, the new one is held here pending an explicit user "Trust" action
+  /// (which moves it into `fingerprint`). nil means no mismatch is pending.
+  var pendingFingerprint: String?
+
   // MARK: - Initialization
 
   /// Creates a new network device instance
@@ -60,7 +65,8 @@ struct NetworkDevice: Identifiable, Codable {
   /// Updates the device information with data from another device, applying
   /// the TOFU fingerprint pin: a mismatch between our stored fingerprint and
   /// the peer's advertised fingerprint causes us to drop the new routing
-  /// info and mark the device inactive (likely impersonation).
+  /// info, mark the device inactive, and stash the incoming fingerprint as
+  /// `pendingFingerprint` so the user can explicitly trust it later.
   mutating func update(with device: NetworkDevice) {
     if let stored = fingerprint,
       let incoming = device.fingerprint,
@@ -68,11 +74,13 @@ struct NetworkDevice: Identifiable, Codable {
     {
       isActive = false
       lastUpdated = Date()
+      pendingFingerprint = incoming
       return
     }
     if fingerprint == nil, let incoming = device.fingerprint {
       fingerprint = incoming
     }
+    pendingFingerprint = nil
     host = device.host
     port = device.port
     lastUpdated = Date()

--- a/Blue Switch/Model/Store/NetworkDeviceStore.swift
+++ b/Blue Switch/Model/Store/NetworkDeviceStore.swift
@@ -95,10 +95,32 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
         NotificationManager.showNotification(
           title: "Identity Mismatch",
           body:
-            "\(device.name) is advertising a different pairing key. Re-pair if you trust this device, otherwise this could be an impersonation attempt."
+            "\(device.name) is advertising a new pairing key. Open Settings → Device and choose Trust if you re-paired the other Mac yourself.",
+          identifier: "identity-mismatch-\(device.id)"
         )
       }
     }
+  }
+
+  /// Promote `pendingFingerprint` to the stored pin and re-mark the device
+  /// active. Invoked from the UI when the user explicitly trusts a new key
+  /// after an Identity Mismatch (e.g., they re-paired the other Mac).
+  func trustPendingFingerprint(for deviceID: String) {
+    guard let index = networkDevices.firstIndex(where: { $0.id == deviceID }),
+      let pending = networkDevices[index].pendingFingerprint
+    else { return }
+    networkDevices[index].fingerprint = pending
+    networkDevices[index].pendingFingerprint = nil
+    networkDevices[index].isActive = true
+    networkDevices[index].lastUpdated = Date()
+    saveNetworkDevices()
+  }
+
+  /// Tear down and re-start Bonjour browsing. Used by the "Refresh" button
+  /// when the discovered list goes stale (network change, sleep/wake).
+  func refreshDiscovery() {
+    discoveredNetworkDevices = []
+    serviceBrowser.refresh()
   }
 
   /// Adds a newly discovered network device
@@ -136,9 +158,12 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
       return
     }
 
-    let title = "New Notification"
-    let body =
-      "You have a new notification from \(Host.current().localizedName ?? "Unknown Device")"
+    let senderName = Host.current().localizedName ?? "another Mac"
+    // Put the sender's name in the title so the receiver's Notification
+    // Center entry is informative at a glance (previously the title was the
+    // generic "New Notification" and the sender's name was buried in the body).
+    let title = "Notification from \(senderName)"
+    let body = "Sent via Blue Switch."
     sendNotificationOverSecure(to: device, title: title, message: body) { result in
       switch result {
       case .success:

--- a/Blue Switch/Model/Store/NetworkDeviceStore.swift
+++ b/Blue Switch/Model/Store/NetworkDeviceStore.swift
@@ -130,7 +130,8 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
     guard PairingStore.shared.isPaired else {
       NotificationManager.showNotification(
         title: "Not Paired",
-        body: "Pair this Mac first to send notifications to \(device.name)."
+        body: "Pair this Mac first to send notifications to \(device.name).",
+        identifier: "notify-not-paired-\(device.id)"
       )
       return
     }
@@ -138,12 +139,22 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
     let title = "New Notification"
     let body =
       "You have a new notification from \(Host.current().localizedName ?? "Unknown Device")"
-    sendNotificationOverSecure(to: device, title: title, message: body)
-
-    NotificationManager.showNotification(
-      title: "Notification Sent",
-      body: "Notification sent to \(device.name)"
-    )
+    sendNotificationOverSecure(to: device, title: title, message: body) { result in
+      switch result {
+      case .success:
+        NotificationManager.showNotification(
+          title: "Notification Sent",
+          body: "Notification sent to \(device.name)",
+          identifier: "notify-sent-\(device.id)"
+        )
+      case .failure(let err):
+        NotificationManager.showNotification(
+          title: "Couldn't Notify \(device.name)",
+          body: err.userMessage,
+          identifier: "notify-failed-\(device.id)"
+        )
+      }
+    }
   }
 
   // MARK: - Private Methods
@@ -205,16 +216,18 @@ extension NetworkDeviceStore {
   }
 
   /// Executes a command on the first connected device through a secure channel.
-  func executeCommand(_ command: DeviceCommand, completion: @escaping (Bool) -> Void) {
+  func executeCommand(
+    _ command: DeviceCommand,
+    completion: @escaping (Result<Void, OutgoingFailure>) -> Void
+  ) {
     guard let device = networkDevices.first else {
       print("No connected devices found")
-      completion(false)
+      completion(.failure(.connectionFailed("no registered device")))
       return
     }
 
     guard PairingStore.shared.isPaired else {
-      print("executeCommand failed: not paired")
-      completion(false)
+      completion(.failure(.notPaired))
       return
     }
 
@@ -249,10 +262,13 @@ extension NetworkDeviceStore {
 
   /// Sends a notification through a secure channel.
   func sendNotificationOverSecure(
-    to device: NetworkDevice, title: String, message: String
+    to device: NetworkDevice,
+    title: String,
+    message: String,
+    completion: @escaping (Result<Void, OutgoingFailure>) -> Void
   ) {
     guard PairingStore.shared.isPaired else {
-      print("sendNotification failed: not paired")
+      completion(.failure(.notPaired))
       return
     }
 
@@ -276,7 +292,7 @@ extension NetworkDeviceStore {
           }
         }
       },
-      completion: { _ in }
+      completion: completion
     )
   }
 }
@@ -284,7 +300,11 @@ extension NetworkDeviceStore {
 extension NetworkDeviceStore {
   func sendPeripheralSync(peripherals: [BluetoothPeripheral], to device: NetworkDevice) {
     guard PairingStore.shared.isPaired else {
-      print("sendPeripheralSync failed: not paired")
+      NotificationManager.showNotification(
+        title: "Not Paired",
+        body: "Pair this Mac first to sync the peripheral list to \(device.name).",
+        identifier: "sync-not-paired-\(device.id)"
+      )
       return
     }
 
@@ -314,7 +334,17 @@ extension NetworkDeviceStore {
           }
         }
       },
-      completion: { _ in }
+      completion: { result in
+        // Sync is a routine background-ish operation, so we stay quiet on
+        // success and only surface failures.
+        if case .failure(let err) = result {
+          NotificationManager.showNotification(
+            title: "Couldn't Sync \(device.name)",
+            body: err.userMessage,
+            identifier: "sync-failed-\(device.id)"
+          )
+        }
+      }
     )
   }
 }

--- a/Blue Switch/View/MenuBar/MenuBarView.swift
+++ b/Blue Switch/View/MenuBar/MenuBarView.swift
@@ -9,6 +9,8 @@ final class MenuBarView: MenuBarPresentable {
 
   private enum Constants {
     enum Menu {
+      static let macsHeader = "Macs"
+      static let peripheralsHeader = "Peripherals"
       static let settings = "Settings..."
       static let quit = "Quit"
     }
@@ -16,6 +18,13 @@ final class MenuBarView: MenuBarPresentable {
     enum KeyEquivalents {
       static let settings = ","
       static let quit = "q"
+    }
+
+    enum Symbols {
+      static let mac = "desktopcomputer"
+      static let peripheral = "keyboard"
+      static let settings = "gearshape"
+      static let quit = "power"
     }
   }
 
@@ -36,52 +45,74 @@ final class MenuBarView: MenuBarPresentable {
   private func createMenu() -> NSMenu {
     let menu = NSMenu()
 
-    addDeviceItems(to: menu)
-    addSettingsItems(to: menu)
-    addQuitItem(to: menu)
+    let macs = networkStore.networkDevices
+    if !macs.isEmpty {
+      menu.addItem(makeSectionHeader(Constants.Menu.macsHeader))
+      for device in macs {
+        menu.addItem(
+          makeItem(title: device.name, symbol: Constants.Symbols.mac, action: nil))
+      }
+      menu.addItem(.separator())
+    }
+
+    let peripherals = bluetoothStore.peripherals
+    if !peripherals.isEmpty {
+      menu.addItem(makeSectionHeader(Constants.Menu.peripheralsHeader))
+      for peripheral in peripherals {
+        menu.addItem(
+          makeItem(
+            title: peripheral.name, symbol: Constants.Symbols.peripheral, action: nil))
+      }
+      menu.addItem(.separator())
+    }
+
+    menu.addItem(
+      makeItem(
+        title: Constants.Menu.settings,
+        symbol: Constants.Symbols.settings,
+        action: #selector(AppDelegate.openPreferencesWindow),
+        keyEquivalent: Constants.KeyEquivalents.settings))
+
+    menu.addItem(
+      makeItem(
+        title: Constants.Menu.quit,
+        symbol: Constants.Symbols.quit,
+        action: #selector(NSApplication.terminate(_:)),
+        keyEquivalent: Constants.KeyEquivalents.quit))
 
     return menu
   }
 
-  private func addDeviceItems(to menu: NSMenu) {
-    addNetworkDeviceItems(to: menu)
-    addSeparator(to: menu)
-    addBluetoothPeripheralItems(to: menu)
-    addSeparator(to: menu)
-  }
-
-  private func addNetworkDeviceItems(to menu: NSMenu) {
-    for device in networkStore.networkDevices {
-      menu.addItem(NSMenuItem(title: device.name, action: nil, keyEquivalent: ""))
+  private func makeItem(
+    title: String,
+    symbol: String,
+    action: Selector?,
+    keyEquivalent: String = ""
+  ) -> NSMenuItem {
+    let item = NSMenuItem(title: title, action: action, keyEquivalent: keyEquivalent)
+    if let img = NSImage(systemSymbolName: symbol, accessibilityDescription: title) {
+      item.image = img
     }
+    return item
   }
 
-  private func addBluetoothPeripheralItems(to menu: NSMenu) {
-    for device in bluetoothStore.peripherals {
-      menu.addItem(NSMenuItem(title: device.name, action: nil, keyEquivalent: ""))
+  /// Bold, disabled, non-selectable section header. Uses the native
+  /// `NSMenuItem.sectionHeader(title:)` on macOS 14+ and a manual styled
+  /// item on earlier versions.
+  private func makeSectionHeader(_ title: String) -> NSMenuItem {
+    if #available(macOS 14.0, *) {
+      return NSMenuItem.sectionHeader(title: title)
     }
-  }
-
-  private func addSettingsItems(to menu: NSMenu) {
-    menu.addItem(
-      NSMenuItem(
-        title: Constants.Menu.settings,
-        action: #selector(AppDelegate.openPreferencesWindow),
-        keyEquivalent: Constants.KeyEquivalents.settings
-      ))
-  }
-
-  private func addQuitItem(to menu: NSMenu) {
-    menu.addItem(
-      NSMenuItem(
-        title: Constants.Menu.quit,
-        action: #selector(NSApplication.terminate(_:)),
-        keyEquivalent: Constants.KeyEquivalents.quit
-      ))
-  }
-
-  private func addSeparator(to menu: NSMenu) {
-    menu.addItem(NSMenuItem.separator())
+    let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+    item.attributedTitle = NSAttributedString(
+      string: title,
+      attributes: [
+        .font: NSFont.boldSystemFont(ofSize: NSFont.smallSystemFontSize),
+        .foregroundColor: NSColor.secondaryLabelColor,
+      ]
+    )
+    item.isEnabled = false
+    return item
   }
 
   private func presentMenu(_ menu: NSMenu, for statusItem: NSStatusItem) {

--- a/Blue Switch/View/Settings/BluetoothPeripheralSettingsView.swift
+++ b/Blue Switch/View/Settings/BluetoothPeripheralSettingsView.swift
@@ -6,6 +6,10 @@ struct BluetoothPeripheralSettingsView: View {
 
   @StateObject private var bluetoothStore = BluetoothPeripheralStore.shared
 
+  // MARK: - State
+
+  @State private var peripheralToRemove: BluetoothPeripheral?
+
   // MARK: - View Content
 
   private var content: some View {
@@ -13,7 +17,7 @@ struct BluetoothPeripheralSettingsView: View {
       RegisteredPeripheralsSectionView(
         peripherals: bluetoothStore.peripherals,
         onPeripheralToggleConnection: handlePeripheralToggleConnection,
-        onPeripheralRemove: handlePeripheralRemove
+        onPeripheralRemoveRequest: { peripheralToRemove = $0 }
       )
 
       AvailablePeripheralsSectionView(
@@ -22,6 +26,18 @@ struct BluetoothPeripheralSettingsView: View {
       )
     }
     .onAppear(perform: handleOnAppear)
+    .alert(item: $peripheralToRemove) { peripheral in
+      Alert(
+        title: Text("Remove \(peripheral.name)?"),
+        message: Text(
+          "It will be removed from Blue Switch's list. Bluetooth pairing with your Mac is not affected; you can add it again from Available Peripherals."
+        ),
+        primaryButton: .destructive(Text("Remove")) {
+          bluetoothStore.removeFromList(peripheral)
+        },
+        secondaryButton: .cancel()
+      )
+    }
   }
 
   var body: some View {
@@ -45,10 +61,6 @@ struct BluetoothPeripheralSettingsView: View {
     }
   }
 
-  private func handlePeripheralRemove(_ peripheral: BluetoothPeripheral) {
-    bluetoothStore.removeFromList(peripheral)
-  }
-
   private func handlePeripheralAdd(_ peripheral: BluetoothPeripheral) {
     bluetoothStore.addPeripheral(peripheral)
   }
@@ -66,19 +78,22 @@ private struct RegisteredPeripheralsSectionView: View {
 
   let peripherals: [BluetoothPeripheral]
   let onPeripheralToggleConnection: (BluetoothPeripheral) -> Void
-  let onPeripheralRemove: (BluetoothPeripheral) -> Void
+  let onPeripheralRemoveRequest: (BluetoothPeripheral) -> Void
 
   var body: some View {
     Section(header: Text("Registered Peripherals")) {
       if peripherals.isEmpty {
-        Text("No registered peripherals")
-          .foregroundColor(.secondary)
+        Text(
+          "Add a paired Bluetooth peripheral from \"Available Peripherals\" below to manage it from the menu bar."
+        )
+        .font(.callout)
+        .foregroundColor(.secondary)
       } else {
         PeripheralListView(
           peripherals: peripherals,
           showConnectionStatus: true,
           primaryAction: onPeripheralToggleConnection,
-          secondaryAction: onPeripheralRemove
+          secondaryAction: onPeripheralRemoveRequest
         )
       }
     }
@@ -93,8 +108,11 @@ private struct AvailablePeripheralsSectionView: View {
   var body: some View {
     Section(header: Text("Available Peripherals")) {
       if peripherals.isEmpty {
-        Text("No available peripherals found")
-          .foregroundColor(.secondary)
+        Text(
+          "No Bluetooth peripherals to add. Pair a keyboard, mouse, or trackpad with this Mac in System Settings first."
+        )
+        .font(.callout)
+        .foregroundColor(.secondary)
       } else {
         PeripheralListView(
           peripherals: peripherals,
@@ -153,12 +171,14 @@ private struct PeripheralRowView: View {
             .foregroundColor(.red)
         }
         .help("Remove this peripheral from Blue Switch's list.")
+        .accessibilityLabel("Remove \(peripheral.name) from list")
       } else {
         Button(action: primaryAction) {
           Image(systemName: "plus.circle")
             .foregroundColor(.blue)
         }
         .help("Add this peripheral to Blue Switch's list.")
+        .accessibilityLabel("Add \(peripheral.name) to list")
       }
     }
   }

--- a/Blue Switch/View/Settings/NetworkDeviceManagementView.swift
+++ b/Blue Switch/View/Settings/NetworkDeviceManagementView.swift
@@ -4,12 +4,14 @@ private enum Constants {
   enum Strings {
     static let connectedDevices = "Connected Devices"
     static let availableDevices = "Available Devices"
-    static let noConnectedDevices = "No connected devices"
-    static let noAvailableDevices = "No available devices found"
-    static let notify = "Notify"
-    static let connect = "Connect"
+    static let noConnectedDevicesHint =
+      "Add another Mac from \"Available Devices\" below to start switching peripherals between them."
+    static let noAvailableDevicesHint =
+      "Make sure Blue Switch is running on your other Mac and both Macs are on the same Wi-Fi network. Then tap Refresh."
     static let connectionLimitMessage =
-      "Only one device can be connected at a time. Please remove existing device first."
+      "Only one device can be connected at a time. Remove the existing device first."
+    static let notify = "Notify"
+    static let add = "Add"
   }
 }
 
@@ -19,6 +21,10 @@ struct NetworkDeviceManagementView: View {
 
   @ObservedObject private var networkStore = NetworkDeviceStore.shared
 
+  // MARK: - State
+
+  @State private var deviceToRemove: NetworkDevice?
+
   // MARK: - View Content
 
   private var formContent: some View {
@@ -26,12 +32,25 @@ struct NetworkDeviceManagementView: View {
       RegisteredDevicesSectionView(
         devices: networkStore.networkDevices,
         onDeviceNotify: handleDeviceNotification,
-        onDeviceRemove: networkStore.removeNetworkDevice
+        onDeviceRemoveRequest: { deviceToRemove = $0 },
+        onTrustPending: handleTrustPending
       )
 
       AvailableDevicesSectionView(
         devices: networkStore.availableNetworkDevices,
         onDeviceRegister: handleDeviceRegistration
+      )
+    }
+    .alert(item: $deviceToRemove) { device in
+      Alert(
+        title: Text("Remove \(device.name)?"),
+        message: Text(
+          "It will be removed from your registered list. You can add it again from Available Devices."
+        ),
+        primaryButton: .destructive(Text("Remove")) {
+          networkStore.removeNetworkDevice(device: device)
+        },
+        secondaryButton: .cancel()
       )
     }
   }
@@ -40,9 +59,12 @@ struct NetworkDeviceManagementView: View {
 
   fileprivate enum Help {
     static let notify = "Send a test notification to this Mac."
-    static let connect = "Add this Mac to your registered list."
-    static let sync = "Send your peripheral list to this Mac."
+    static let add = "Add this Mac to your registered list."
+    static let sync = "Send your peripheral list to this Mac so it knows about them."
     static let remove = "Remove this Mac from the registered list."
+    static let refresh = "Re-scan the network for other Macs running Blue Switch."
+    static let trust =
+      "Pin the new pairing key. Only do this if you intentionally re-paired the other Mac."
     static let needsPairing = "Pair this Mac in the Pairing tab first."
   }
 
@@ -64,6 +86,10 @@ struct NetworkDeviceManagementView: View {
   private func handleDeviceRegistration(_ device: NetworkDevice) {
     networkStore.registerNetworkDevice(device: device)
   }
+
+  private func handleTrustPending(_ device: NetworkDevice) {
+    networkStore.trustPendingFingerprint(for: device.id)
+  }
 }
 
 // MARK: - Supporting Views
@@ -76,12 +102,14 @@ private struct RegisteredDevicesSectionView: View {
   // MARK: - Properties
   let devices: [NetworkDevice]
   let onDeviceNotify: (NetworkDevice) -> Void
-  let onDeviceRemove: (NetworkDevice) -> Void
+  let onDeviceRemoveRequest: (NetworkDevice) -> Void
+  let onTrustPending: (NetworkDevice) -> Void
 
   var body: some View {
     Section {
       if devices.isEmpty {
-        Text(Constants.Strings.noConnectedDevices)
+        Text(Constants.Strings.noConnectedDevicesHint)
+          .font(.callout)
           .foregroundColor(.secondary)
       } else {
         NetworkDeviceListView(
@@ -90,13 +118,14 @@ private struct RegisteredDevicesSectionView: View {
           actionHelp: NetworkDeviceManagementView.Help.notify,
           requiresPairing: true,
           action: onDeviceNotify,
-          onDelete: onDeviceRemove,
+          onDelete: onDeviceRemoveRequest,
           onSyncPeripherals: { device in
             networkStore.sendPeripheralSync(
               peripherals: bluetoothStore.peripherals,
               to: device
             )
-          }
+          },
+          onTrustPending: onTrustPending
         )
       }
     } header: {
@@ -117,20 +146,33 @@ private struct AvailableDevicesSectionView: View {
   let onDeviceRegister: (NetworkDevice) -> Void
 
   var body: some View {
-    Section(header: Text(Constants.Strings.availableDevices).font(.headline)) {
-      if !self.networkStore.networkDevices.isEmpty {
+    Section {
+      if !networkStore.networkDevices.isEmpty {
         Text(Constants.Strings.connectionLimitMessage)
           .foregroundColor(.secondary)
       } else if devices.isEmpty {
-        Text(Constants.Strings.noAvailableDevices)
+        Text(Constants.Strings.noAvailableDevicesHint)
+          .font(.callout)
           .foregroundColor(.secondary)
       } else {
         NetworkDeviceListView(
           devices: devices,
-          buttonTitle: Constants.Strings.connect,
-          actionHelp: NetworkDeviceManagementView.Help.connect,
+          buttonTitle: Constants.Strings.add,
+          actionHelp: NetworkDeviceManagementView.Help.add,
           action: onDeviceRegister
         )
+      }
+    } header: {
+      HStack {
+        Text(Constants.Strings.availableDevices)
+          .font(.headline)
+        Spacer()
+        Button(action: { networkStore.refreshDiscovery() }) {
+          Image(systemName: "arrow.clockwise")
+        }
+        .buttonStyle(.borderless)
+        .help(NetworkDeviceManagementView.Help.refresh)
+        .accessibilityLabel("Refresh available devices")
       }
     }
   }
@@ -146,6 +188,7 @@ private struct NetworkDeviceListView: View {
   let action: (NetworkDevice) -> Void
   let onDelete: ((NetworkDevice) -> Void)?
   let onSyncPeripherals: ((NetworkDevice) -> Void)?
+  let onTrustPending: ((NetworkDevice) -> Void)?
 
   @ObservedObject private var pairing = PairingStore.shared
 
@@ -156,7 +199,8 @@ private struct NetworkDeviceListView: View {
     requiresPairing: Bool = false,
     action: @escaping (NetworkDevice) -> Void,
     onDelete: ((NetworkDevice) -> Void)? = nil,
-    onSyncPeripherals: ((NetworkDevice) -> Void)? = nil
+    onSyncPeripherals: ((NetworkDevice) -> Void)? = nil,
+    onTrustPending: ((NetworkDevice) -> Void)? = nil
   ) {
     self.devices = devices
     self.buttonTitle = buttonTitle
@@ -165,6 +209,7 @@ private struct NetworkDeviceListView: View {
     self.action = action
     self.onDelete = onDelete
     self.onSyncPeripherals = onSyncPeripherals
+    self.onTrustPending = onTrustPending
   }
 
   private var blockedByPairing: Bool {
@@ -173,34 +218,56 @@ private struct NetworkDeviceListView: View {
 
   var body: some View {
     List(devices) { device in
-      HStack {
-        Text(device.name)
-        Spacer()
-        Button(action: { action(device) }) {
-          Text(buttonTitle)
-        }
-        .disabled(!device.isActive || blockedByPairing)
-        .help(blockedByPairing ? NetworkDeviceManagementView.Help.needsPairing : actionHelp)
-
-        if let onSync = onSyncPeripherals {
-          Button(action: { onSync(device) }) {
-            Image(systemName: "arrow.triangle.2.circlepath")
-              .foregroundColor(.blue)
+      VStack(alignment: .leading, spacing: 6) {
+        HStack {
+          Text(device.name)
+          Spacer()
+          Button(action: { action(device) }) {
+            Text(buttonTitle)
           }
           .disabled(!device.isActive || blockedByPairing)
-          .help(
-            blockedByPairing
-              ? NetworkDeviceManagementView.Help.needsPairing
-              : NetworkDeviceManagementView.Help.sync
-          )
+          .help(blockedByPairing ? NetworkDeviceManagementView.Help.needsPairing : actionHelp)
+
+          if let onSync = onSyncPeripherals {
+            Button(action: { onSync(device) }) {
+              Image(systemName: "square.and.arrow.up")
+                .foregroundColor(.blue)
+            }
+            .disabled(!device.isActive || blockedByPairing)
+            .help(
+              blockedByPairing
+                ? NetworkDeviceManagementView.Help.needsPairing
+                : NetworkDeviceManagementView.Help.sync
+            )
+            .accessibilityLabel("Send peripheral list to \(device.name)")
+          }
+
+          if let onDelete = onDelete {
+            Button(action: { onDelete(device) }) {
+              Image(systemName: "trash")
+                .foregroundColor(.red)
+            }
+            .help(NetworkDeviceManagementView.Help.remove)
+            .accessibilityLabel("Remove \(device.name)")
+          }
         }
 
-        if let onDelete = onDelete {
-          Button(action: { onDelete(device) }) {
-            Image(systemName: "trash")
-              .foregroundColor(.red)
+        if let onTrustPending = onTrustPending, device.pendingFingerprint != nil {
+          HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+              .foregroundColor(.yellow)
+              .accessibilityHidden(true)
+            Text("New pairing key advertised.")
+              .font(.caption)
+              .foregroundColor(.secondary)
+            Spacer()
+            Button("Trust") {
+              onTrustPending(device)
+            }
+            .help(NetworkDeviceManagementView.Help.trust)
+            .accessibilityLabel("Trust new key for \(device.name)")
           }
-          .help(NetworkDeviceManagementView.Help.remove)
+          .padding(.vertical, 2)
         }
       }
     }

--- a/Blue Switch/View/Settings/PairingSettingsView.swift
+++ b/Blue Switch/View/Settings/PairingSettingsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Settings tab for managing the device-pairing pre-shared key.
@@ -92,6 +93,28 @@ struct PairingSettingsView: View {
   }
 }
 
+// MARK: - Selectable code helper
+
+extension View {
+  /// Applies `.textSelection(.enabled)` on macOS 12+, no-op otherwise. The
+  /// project's deployment target still includes 11.x where the modifier
+  /// isn't available.
+  @ViewBuilder
+  func userSelectable() -> some View {
+    if #available(macOS 12.0, *) {
+      self.textSelection(.enabled)
+    } else {
+      self
+    }
+  }
+}
+
+private func copyToPasteboard(_ text: String) {
+  let pb = NSPasteboard.general
+  pb.clearContents()
+  pb.setString(text, forType: .string)
+}
+
 // MARK: - Generate Code Sheet
 
 private struct GenerateCodeSheet: View {
@@ -99,13 +122,29 @@ private struct GenerateCodeSheet: View {
   @ObservedObject private var pairing = PairingStore.shared
   @State private var code: String = ""
   @State private var errorMessage: String?
+  @State private var isPairing = false
+
+  private var formattedCode: String {
+    PairingStore.formatCode(code)
+  }
 
   var body: some View {
     VStack(spacing: 20) {
       Text("Pairing Code")
         .font(.headline)
-      Text(PairingStore.formatCode(code))
+      Text(formattedCode)
         .font(.system(size: 32, weight: .bold, design: .monospaced))
+        .userSelectable()
+        .accessibilityLabel("Pairing code: \(formattedCode)")
+      HStack {
+        Button {
+          copyToPasteboard(formattedCode)
+        } label: {
+          Label("Copy", systemImage: "doc.on.doc")
+        }
+        .help("Copy the pairing code to the clipboard.")
+        .accessibilityLabel("Copy pairing code")
+      }
       Text("Enter this code on your other Mac.")
         .foregroundColor(.secondary)
         .font(.caption)
@@ -115,30 +154,44 @@ private struct GenerateCodeSheet: View {
           .font(.caption)
       }
       HStack {
+        if isPairing {
+          ProgressView()
+            .controlSize(.small)
+        }
+        Spacer()
         Button("Cancel") {
           isPresented = false
         }
+        .disabled(isPairing)
         .help("Close without saving this code.")
         Button("I've entered this on my other Mac") {
-          do {
-            try pairing.pair(withCode: code)
-            isPresented = false
-          } catch {
-            errorMessage = "Failed to save pairing key."
-          }
+          startPair()
         }
         .keyboardShortcut(.defaultAction)
+        .disabled(isPairing)
         .help("Save this code as the pairing key on this Mac.")
       }
     }
     .padding(24)
     .frame(width: 460)
     .onAppear {
-      // Fresh code per sheet presentation; the @State default initializer
-      // can be reused across re-evaluations and would otherwise show a
-      // previously-shown-but-discarded code.
       code = PairingStore.generateCode()
       errorMessage = nil
+      isPairing = false
+    }
+  }
+
+  private func startPair() {
+    isPairing = true
+    errorMessage = nil
+    pairing.pair(withCode: code) { result in
+      isPairing = false
+      switch result {
+      case .success:
+        isPresented = false
+      case .failure:
+        errorMessage = "Failed to save pairing key."
+      }
     }
   }
 }
@@ -150,6 +203,7 @@ private struct EnterCodeSheet: View {
   @ObservedObject private var pairing = PairingStore.shared
   @State private var input: String = ""
   @State private var errorMessage: String?
+  @State private var isPairing = false
 
   var body: some View {
     VStack(spacing: 20) {
@@ -158,6 +212,7 @@ private struct EnterCodeSheet: View {
       TextField("XXXX-XXXX-XXXX", text: $input)
         .textFieldStyle(RoundedBorderTextFieldStyle())
         .font(.system(.title2, design: .monospaced))
+        .disabled(isPairing)
         .onChange(of: input) { newValue in
           let normalized = PairingStore.normalize(newValue)
           let limited = String(normalized.prefix(PairingStore.codeLength))
@@ -172,29 +227,52 @@ private struct EnterCodeSheet: View {
           .font(.caption)
       }
       HStack {
+        if isPairing {
+          ProgressView()
+            .controlSize(.small)
+        }
+        Spacer()
         Button("Cancel") {
           isPresented = false
         }
+        .disabled(isPairing)
         .help("Close without pairing.")
         Button("Pair") {
-          let normalized = PairingStore.normalize(input)
-          guard PairingStore.isValid(normalized) else {
-            errorMessage = "Code must be 12 characters from the pairing alphabet."
-            return
-          }
-          do {
-            try pairing.pair(withCode: normalized)
-            isPresented = false
-          } catch {
-            errorMessage = "Failed to derive or save pairing key."
-          }
+          startPair()
         }
         .keyboardShortcut(.defaultAction)
+        .disabled(isPairing)
         .help("Save the entered code as the pairing key on this Mac.")
       }
     }
     .padding(24)
     .frame(width: 420)
+  }
+
+  private func startPair() {
+    let normalized = PairingStore.normalize(input)
+    guard PairingStore.isValid(normalized) else {
+      errorMessage = "Code must be 12 characters from the pairing alphabet."
+      return
+    }
+    isPairing = true
+    errorMessage = nil
+    pairing.pair(withCode: normalized) { result in
+      isPairing = false
+      switch result {
+      case .success:
+        isPresented = false
+      case .failure(let err):
+        switch err {
+        case .invalidCode:
+          errorMessage = "Invalid code."
+        case .derivationFailed:
+          errorMessage = "Couldn't derive a key from that code."
+        case .keychainFailed:
+          errorMessage = "Couldn't save the key to the keychain."
+        }
+      }
+    }
   }
 }
 

--- a/Blue Switch/View/Settings/SettingsView.swift
+++ b/Blue Switch/View/Settings/SettingsView.swift
@@ -18,33 +18,40 @@ struct SettingsView: View {
   /// Window dimensions for the settings view
   private let windowSize = CGSize(width: 600, height: 400)
 
+  /// Persisted across launches so reopening Settings returns to the same tab.
+  @AppStorage("settings-selected-tab") private var selectedTab: Int = 0
+
   // MARK: - View Content
 
   var body: some View {
-    TabView {
+    TabView(selection: $selectedTab) {
       BluetoothPeripheralSettingsView()
         .tabItem {
           Label(TabItem.devices.text, systemImage: TabItem.devices.image)
         }
         .help("Manage Bluetooth peripherals (keyboards, mice) to switch between Macs.")
+        .tag(0)
 
       NetworkDeviceManagementView()
         .tabItem {
           Label(TabItem.mac.text, systemImage: TabItem.mac.image)
         }
         .help("Manage the other Macs on your network.")
+        .tag(1)
 
       PairingSettingsView()
         .tabItem {
           Label(TabItem.pairing.text, systemImage: TabItem.pairing.image)
         }
         .help("Set up the pairing key between this Mac and your other Mac.")
+        .tag(2)
 
       OtherSettingsView()
         .tabItem {
           Label(TabItem.other.text, systemImage: TabItem.other.image)
         }
         .help("License and other settings.")
+        .tag(3)
     }
     .frame(width: windowSize.width, height: windowSize.height)
   }


### PR DESCRIPTION
## Summary

- Address the P0/P1 findings from the recent audit: handshake double-completion, command/data frame ambiguity, monotonic rate limiter, missing `NSBonjourServices` (broke discovery on macOS 14+), unchecked-in Xcode scheme, release pipeline gating against a `v0.0.0` overwrite, Bonjour TOFU pin, and `BluetoothManager` state surfacing.
- Fix two user-reported bugs: peripheral disconnects automatically a moment after "Connect to PC" (we weren't retaining `IOBluetoothDevicePair`), and the button title didn't update until you switched tabs (no observable state).
- A large UI/UX polish pass:
  - **Failure surfacing** — Notify, Sync, and the menu-bar switch now post user-facing notifications with categorised reasons (e.g. "Pairing codes don't match. Re-pair both Macs with the same code.") and stable identifiers so retries collapse.
  - **Device tab** — "Connect" renamed to "Add"; trash and remove confirm before deleting; VoiceOver labels on every icon-only button; sync icon swapped from `arrow.triangle.2.circlepath` to `square.and.arrow.up`; Refresh button in the Available Devices header; Identity Mismatch is now actionable in-app (yellow banner with a Trust button that pins the new fingerprint); empty states give concrete next steps.
  - **Peripheral tab** — remove-from-list confirms; VoiceOver labels on plus/minus icons; actionable empty states.
  - **Pairing tab** — code is selectable on macOS 12+ with an explicit Copy button; PBKDF2 derivation runs off-main with a spinner during the ~half-second hang.
  - **Settings root** — last selected tab persists across launches.
  - **Menu bar** — each item has an SF Symbol (desktopcomputer / keyboard / gearshape / power) plus bold "Macs" / "Peripherals" section headers.
  - **Status bar icon** — switches to an exclamation triangle when the app can't function (unpaired, Bluetooth off / unauthorized / unsupported) with a tooltip + accessibility label explaining why.
  - **Partial-state warning** — now tells the user what to do instead of being abstract.
  - **Receiver notification** — shows sender hostname in the title rather than burying it in the body.
- Add a Launch at Login toggle (macOS 13+ via SMAppService).