### PR TITLE
fix(docs): correct stale pairing-code length and entropy in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A macOS menu-bar utility that hands off Magic Keyboard, Magic Trackpad, and Magic Mouse between two Macs with one click — no KVM, no cables.
 
-This is a security-hardened fork of [HoshimuraYuto/blue-switch](https://github.com/HoshimuraYuto/blue-switch). The original ships an unauthenticated, unencrypted LAN protocol that lets anyone on the same Wi-Fi take over your Bluetooth peripherals or spoof notifications. This fork replaces that channel with a sealed, mutually-authenticated channel keyed by a 9-character pairing code you share between your two Macs.
+This is a security-hardened fork of [HoshimuraYuto/blue-switch](https://github.com/HoshimuraYuto/blue-switch). The original ships an unauthenticated, unencrypted LAN protocol that lets anyone on the same Wi-Fi take over your Bluetooth peripherals or spoof notifications. This fork replaces that channel with a sealed, mutually-authenticated channel keyed by a 12-character pairing code you share between your two Macs.
 
 ## Installation
 
@@ -20,7 +20,7 @@ Do this on **both** Macs.
    - **Peripheral** tab: tick the Magic devices you want Blue Switch to manage.
    - **Device** tab: pick the other Mac from "Available Devices."
 4. **Pairing** tab — *new in this fork, required*:
-   - On one Mac, click "Generate Code." A nine-character code appears.
+   - On one Mac, click "Generate Code." A twelve-character code appears.
    - On the other, click "Enter Code" and type it in.
    - Both Macs should show the same eight-character fingerprint after pairing. If they don't, you typed the code wrong.
 5. Hit the sync button on the **Device** tab to share your peripheral list with the other Mac.
@@ -43,7 +43,7 @@ Until step 4 completes, the switch action and peripheral sync refuse to talk to 
 
 ## Developer notes
 
-Requirements: Xcode 16.1+, Swift 6.
+Requirements: Xcode 16.1+ (Swift 5 language mode).
 
 Build:
 ```bash
@@ -59,11 +59,11 @@ This sets `core.hooksPath` to the in-repo `.hooks/` directory, so be aware you'r
 
 ## Security model
 
-The LAN channel uses a shared symmetric key derived from the nine-character pairing code via PBKDF2-HMAC-SHA256 (600k iterations) and stored in the Keychain. Per connection, both sides exchange a 32-byte nonce and derive direction-specific session keys via HKDF; messages are framed as length-prefixed ChaCha20-Poly1305 sealed boxes with monotonic counter nonces. Failed authentications are rate-limited per source IP (5 failures / 60s → 15-minute block).
+The LAN channel uses a shared symmetric key derived from the twelve-character pairing code via PBKDF2-HMAC-SHA256 (600k iterations) and stored in the Keychain. Per connection, both sides exchange a 32-byte nonce and derive direction-specific session keys via HKDF; messages are framed as length-prefixed ChaCha20-Poly1305 sealed boxes with monotonic counter nonces. Failed authentications are rate-limited per source IP (5 failures / 60s → 15-minute block).
 
 Known limits:
 - The build isn't code-signed or notarized.
-- Forty-five bits of entropy in the pairing code is fine against an online attacker (rate limit makes brute force infeasible) but theoretically grindable offline if someone captures ciphertext. PBKDF2 stretching pushes the cost up but doesn't eliminate it; a PAKE would close the gap and is the obvious next step.
+- Sixty bits of entropy in the pairing code is fine against an online attacker (rate limit makes brute force infeasible) but theoretically grindable offline if someone captures ciphertext. PBKDF2 stretching pushes the cost up but doesn't eliminate it; a PAKE would close the gap and is the obvious next step.
 
 ## License
 


### PR DESCRIPTION
The pairing code was bumped from 9 to 12 characters in bfaa95c (the "harden auth stack" change that also rotated the PBKDF salt to v2), but the README still described the code as nine characters in three places and quoted the old 45-bit entropy figure. With the 32-character Crockford Base32 alphabet, a 12-char code carries 12 * log2(32) = 60 bits.

Also clarify the toolchain note: the project compiles in Swift 5 language mode (SWIFT_VERSION = 5.0 in the pbxproj), even though Xcode 16.1 ships the Swift 6 compiler.