### PR TITLE
fix(ui): stop Settings window getting dismissed by its own opening menu

### DIFF
--- a/Blue Switch/AppDelegate/AppDelegate.swift
+++ b/Blue Switch/AppDelegate/AppDelegate.swift
@@ -324,7 +324,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       forName: NSWindow.willCloseNotification,
       object: nil,
       queue: .main
-    ) { [weak self] _ in
+    ) { [weak self] notification in
+      // Only react when a normal-level window closes. The right-click
+      // NSMenu fires willClose as soon as the user picks Settings —
+      // reacting to that races against the Settings window actually
+      // appearing (we'd flip back to .accessory before SwiftUI has put
+      // the window on screen, killing the open). Status-item windows
+      // and popovers live at non-`.normal` levels and would hit the
+      // same race.
+      guard let window = notification.object as? NSWindow,
+        window.level == .normal
+      else { return }
       // `willClose` fires while the closing window is still flagged visible;
       // defer one runloop tick so the count reflects the post-close state.
       DispatchQueue.main.async {


### PR DESCRIPTION
The Dock-icon observer reacted to *any* willCloseNotification — and the NSMenu shown for the right-click status item fires that notification the moment the user picks "Settings…". The observer then deferred one runloop tick and checked NSApp.windows; the Settings scene's window hadn't been put on screen yet, so the filter saw zero normal-level windows and flipped the activation policy back to `.accessory`. SwiftUI finished opening the window into a no-Dock-icon state, which manifests as a Dock flash and no visible Settings window.

Filter the observer on the closing window's level: only react when a `.normal` window closes. Menus (`.popUpMenu`), status items (`.statusBar`), and popovers all live above `.normal`, so they no longer trip the transition. The Settings window itself is `.normal`, so the back-to-accessory step still fires when the user actually closes Settings.