### PR TITLE
feat(ui): Cmd+Q / Dock-Quit close Settings instead of exiting

### DIFF
--- a/Blue Switch/AppDelegate/AppDelegate.swift
+++ b/Blue Switch/AppDelegate/AppDelegate.swift
@@ -22,6 +22,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   /// the scene's `showSettingsWindow:` action silently fails to produce a
   /// visible window in this app (LSUIElement + `.accessory`).
   private var settingsWindowController: NSWindowController?
+  /// Set true by `quitFromStatusBar(_:)` immediately before invoking
+  /// `terminate(_:)`. `applicationShouldTerminate(_:)` checks this to
+  /// distinguish "user picked Quit from our menu-bar menu" (real exit)
+  /// from "user pressed Cmd+Q with Settings focused or chose Quit from
+  /// the Dock" (just close the window, keep running).
+  private var quitFromStatusBarMenu = false
 
   // MARK: - Lifecycle Methods
 
@@ -45,6 +51,54 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       return false
     }
     return true
+  }
+
+  /// Decide whether a `terminate(_:)` request should actually exit.
+  ///
+  /// - Status-bar menu → Quit: real exit (the flag is set in `quitFromStatusBar`).
+  /// - System-initiated (logout / shutdown / restart): real exit.
+  /// - Anything else (Cmd+Q while Settings focused, right-click Dock → Quit,
+  ///   etc.): cancel the terminate, just close Settings and drop the Dock
+  ///   icon. This is the "Blue Switch lives in the menu bar; the Dock entry
+  ///   is only there while Settings is open" mental model the user wants.
+  func applicationShouldTerminate(
+    _ sender: NSApplication
+  ) -> NSApplication.TerminateReply {
+    if quitFromStatusBarMenu { return .terminateNow }
+    if Self.isSystemInitiatedQuit() { return .terminateNow }
+    // Close any visible normal-level windows (the Settings window is the
+    // only one this app ever has). The willClose observer in
+    // `setupActivationPolicyTracking` will demote the activation policy
+    // back to `.accessory` shortly after; setting it here too just makes
+    // the Dock-icon disappearance feel immediate.
+    for window in NSApp.windows where window.isVisible && window.level == .normal {
+      window.close()
+    }
+    NSApp.setActivationPolicy(.accessory)
+    return .terminateCancel
+  }
+
+  /// True when the current AppleEvent reason is logout / shutdown / restart.
+  /// Without this check we'd block the system from quitting us during
+  /// shutdown, which can hang the logout flow.
+  private static func isSystemInitiatedQuit() -> Bool {
+    guard let event = NSAppleEventManager.shared().currentAppleEvent,
+      let reason = event.attributeDescriptor(forKeyword: AEKeyword(kAEQuitReason))?
+        .enumCodeValue
+    else { return false }
+    return reason == kAELogOut
+      || reason == kAEReallyLogOut
+      || reason == kAEShowRestartDialog
+      || reason == kAEShowShutdownDialog
+      || reason == kAERestart
+      || reason == kAEShutDown
+  }
+
+  /// Status-bar menu's Quit handler. Sets the "real quit" flag so
+  /// `applicationShouldTerminate` lets us exit.
+  @objc func quitFromStatusBar(_ sender: Any?) {
+    quitFromStatusBarMenu = true
+    NSApp.terminate(sender)
   }
 
   deinit {

--- a/Blue Switch/View/MenuBar/MenuBarView.swift
+++ b/Blue Switch/View/MenuBar/MenuBarView.swift
@@ -97,11 +97,15 @@ final class MenuBarView: MenuBarPresentable {
         action: #selector(AppDelegate.openSettingsWindow(_:)),
         keyEquivalent: Constants.KeyEquivalents.settings))
 
+    // Route through AppDelegate so the status-bar Quit really exits;
+    // `applicationShouldTerminate` cancels other terminate sources
+    // (Cmd+Q with Settings focused, Dock-icon → Quit) and just closes
+    // the Settings window instead.
     menu.addItem(
       makeItem(
         title: Constants.Menu.quit,
         symbol: Constants.Symbols.quit,
-        action: #selector(NSApplication.terminate(_:)),
+        action: #selector(AppDelegate.quitFromStatusBar(_:)),
         keyEquivalent: Constants.KeyEquivalents.quit))
 
     return menu


### PR DESCRIPTION
The mental model the user has for this app is: "Blue Switch lives in the menu bar. The Dock icon is just a side-effect of Settings being open." So Cmd+Q with the Settings window focused, or right-click Dock icon → Quit, both terminate-ing the app surprised them — they expected those to dismiss Settings, the way clicking the red X does.

Reroute the status-bar menu's Quit through a new
`quitFromStatusBar(_:)` that sets a `quitFromStatusBarMenu` flag before invoking `NSApp.terminate(_:)`. Add an
`applicationShouldTerminate(_:)` that returns `.terminateNow` when:

- the flag is set (explicit Quit from our menu), or
- the AppleEvent reason is a system-initiated quit (logout / shutdown / restart) — without this check we'd block logout, which can stall the system.

Anything else (Cmd+Q with Settings focused, Dock-icon right-click → Quit, etc.) hits the catch-all branch: close all visible normal-level windows, drop activation policy to `.accessory`, return `.terminateCancel`. The willCloseNotification observer would have demoted policy on its own a tick later; setting it inline just makes the Dock-icon disappearance feel immediate.

Closing windows by iterating `NSApp.windows where … level == .normal` keeps this working for both the SwiftUI Settings-scene path on `main` and the manual NSWindow path waiting in PR #12 — neither relies on the window being held in a specific property.