### PR TITLE
fix(pairing): revert data protection keychain so unsigned builds can …

### DIFF
--- a/Blue Switch/Manager/PairingStore.swift
+++ b/Blue Switch/Manager/PairingStore.swift
@@ -25,11 +25,14 @@ final class PairingStore: ObservableObject {
   private static let pbkdfSalt = "BlueSwitch-PSK-v2"
   private static let pbkdfIterations: UInt32 = 600_000
   private static let pbkdfKeyLength = 32
-  /// Bumped from `psk-v2` when we moved to the data protection keychain.
-  /// The legacy keychain and the data protection keychain are separate
-  /// stores; bumping the service name makes the migration explicit and
-  /// prevents the legacy item from shadowing the new one if a user ever
-  /// downgrades and re-pairs.
+  /// Service name reflects the previous `psk-v3` data-protection-keychain
+  /// attempt that was reverted: `kSecUseDataProtectionKeychain` requires
+  /// either a real Team ID or a sandbox-derived access group, neither of
+  /// which an ad-hoc-signed sandboxed build of this app has. `SecItemAdd`
+  /// fails with `errSecMissingEntitlement` (-34018) and pairing breaks.
+  /// We kept the v3 service name so the boundary in users' keychains is
+  /// still explicit — items at v3 in the legacy keychain are this fork's;
+  /// items at v2 are from before that breaking change.
   private static let keychainService = "com.blueswitch.psk-v3"
   private static let keychainAccount = "shared"
 
@@ -129,7 +132,6 @@ final class PairingStore: ObservableObject {
         kSecClass as String: kSecClassGenericPassword,
         kSecAttrService as String: Self.keychainService,
         kSecAttrAccount as String: Self.keychainAccount,
-        kSecUseDataProtectionKeychain as String: true,
       ]
       let status = SecItemDelete(query as CFDictionary)
       DispatchQueue.main.async {
@@ -206,7 +208,6 @@ final class PairingStore: ObservableObject {
       kSecAttrAccount as String: Self.keychainAccount,
       kSecReturnData as String: true,
       kSecMatchLimit as String: kSecMatchLimitOne,
-      kSecUseDataProtectionKeychain as String: true,
     ]
     var item: CFTypeRef?
     let status = SecItemCopyMatching(query as CFDictionary, &item)
@@ -219,7 +220,6 @@ final class PairingStore: ObservableObject {
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrService as String: Self.keychainService,
       kSecAttrAccount as String: Self.keychainAccount,
-      kSecUseDataProtectionKeychain as String: true,
     ]
     SecItemDelete(delete as CFDictionary)
 
@@ -230,7 +230,6 @@ final class PairingStore: ObservableObject {
       kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
       kSecAttrSynchronizable as String: false,
       kSecValueData as String: data,
-      kSecUseDataProtectionKeychain as String: true,
     ]
     let status = SecItemAdd(add as CFDictionary, nil)
     guard status == errSecSuccess else {

--- a/Blue Switch/View/Settings/PairingSettingsView.swift
+++ b/Blue Switch/View/Settings/PairingSettingsView.swift
@@ -268,8 +268,8 @@ private struct EnterCodeSheet: View {
           errorMessage = "Invalid code."
         case .derivationFailed:
           errorMessage = "Couldn't derive a key from that code."
-        case .keychainFailed:
-          errorMessage = "Couldn't save the key to the keychain."
+        case .keychainFailed(let status):
+          errorMessage = "Couldn't save the key to the keychain (error \(status))."
         }
       }
     }


### PR DESCRIPTION
…pair

`kSecUseDataProtectionKeychain` was added in v2.0.4 with the goal of sidestepping the legacy macOS keychain's per-item ACL prompts. On macOS the data protection keychain requires either a real Team ID or an explicit sandbox-derived access group. This app is sandboxed but has no Team ID and no `keychain-access-groups` entitlement, so the ad-hoc-signed unsigned release falls back into a state where `SecItemAdd` rejects with `errSecMissingEntitlement` (-34018). The symptom on the user side: pairing fails immediately with "Couldn't save the key to the keychain."

Drop the `kSecUseDataProtectionKeychain` flag from all four queries (read / write delete / write add / unpair). We keep the `psk-v3` service name so the migration boundary in users' keychains is still documented — items at v3 in the legacy keychain are this fork's; v2 is the older state.

Also surface the `OSStatus` in the user-visible error message so the next time the keychain throws we can read the code without attaching a debugger.

The unpair-on-first-click and off-main-keychain-call fixes from v2.0.4 are unaffected — those didn't depend on the data protection keychain.