### PR TITLE
fix(pairing): surface unpair failures in the Pairing tab itself

### DIFF
--- a/Blue Switch/Manager/PairingStore.swift
+++ b/Blue Switch/Manager/PairingStore.swift
@@ -125,7 +125,15 @@ final class PairingStore: ObservableObject {
   /// keychain — the re-read could trigger a second authorization prompt
   /// on the same item we just had to authorize, which manifested as the
   /// user needing to click Unpair twice.
-  func unpair() {
+  ///
+  /// `completion` receives `nil` on success or the underlying `OSStatus`
+  /// when SecItemDelete fails for any reason other than "item not found".
+  /// We pass that back so the Pairing tab can render an inline error in
+  /// the view itself — system notifications are unreliable on
+  /// ad-hoc-signed sandboxed builds (UNUserNotificationCenter refuses to
+  /// authorize them), so an Unpair that fails would otherwise look like
+  /// "nothing happened".
+  func unpair(completion: ((OSStatus?) -> Void)? = nil) {
     DispatchQueue.global(qos: .userInitiated).async { [weak self] in
       guard let self = self else { return }
       let query: [String: Any] = [
@@ -134,17 +142,14 @@ final class PairingStore: ObservableObject {
         kSecAttrAccount as String: Self.keychainAccount,
       ]
       let status = SecItemDelete(query as CFDictionary)
+      print("PairingStore.unpair: SecItemDelete -> \(status)")
       DispatchQueue.main.async {
         if status == errSecSuccess || status == errSecItemNotFound {
           self.isPaired = false
           self.fingerprint = nil
+          completion?(nil)
         } else {
-          NotificationManager.showNotification(
-            title: "Couldn't Unpair",
-            body:
-              "macOS returned error \(status) clearing the saved pairing key. Try again from Settings → Pairing.",
-            identifier: "unpair-failed"
-          )
+          completion?(status)
         }
       }
     }

--- a/Blue Switch/View/Settings/PairingSettingsView.swift
+++ b/Blue Switch/View/Settings/PairingSettingsView.swift
@@ -10,6 +10,7 @@ struct PairingSettingsView: View {
   @State private var showGenerateSheet = false
   @State private var showEnterSheet = false
   @State private var showUnpairAlert = false
+  @State private var unpairErrorStatus: OSStatus?
 
   // MARK: - Body
 
@@ -35,7 +36,10 @@ struct PairingSettingsView: View {
           "Blue Switch will stop accepting commands from your other Mac until you pair again."
         ),
         primaryButton: .destructive(Text("Unpair")) {
-          pairing.unpair()
+          unpairErrorStatus = nil
+          pairing.unpair { status in
+            unpairErrorStatus = status
+          }
         },
         secondaryButton: .cancel()
       )
@@ -87,6 +91,11 @@ struct PairingSettingsView: View {
       }
       .foregroundColor(.red)
       .help("Remove the saved pairing key. This Mac will stop accepting commands.")
+      if let status = unpairErrorStatus {
+        Text("Couldn't unpair: keychain returned error \(status).")
+          .foregroundColor(.red)
+          .font(.caption)
+      }
       Spacer()
     }
     .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
`unpair()` previously reported failures via `NotificationManager.show Notification`, which is unreliable on the ad-hoc-signed sandboxed release of this app — `UNUserNotificationCenter.requestAuthorization` returns `UNErrorDomain Code=1` (not allowed) so the notification just gets dropped on the floor. From the user's perspective, clicking Unpair looked like nothing happened: the keychain delete may have been failing, but neither the state change nor the error notification surfaced.

Plumb the `OSStatus` from `SecItemDelete` back to the Pairing tab via a completion handler, and render the failure inline under the Unpair button when one occurs. Also log the status to stderr — running the
app from Terminal now prints `PairingStore.unpair: SecItemDelete ->
<status>` on every attempt, which lets the user (or me) see what macOS actually returned without attaching a debugger.

This is diagnostic plumbing more than a guaranteed fix: if SecItemDelete is silently succeeding and a different layer is the culprit, the inline message won't appear and we'll know to look further up. But if the keychain is returning an error code that the previous notification-based surface swallowed, it'll now show in the UI.