### PR TITLE
feat: pairing UX polish, outbound rate limit, and review-driven fixes

### DIFF
--- a/Magic Switch/AppDelegate/AppDelegate.swift
+++ b/Magic Switch/AppDelegate/AppDelegate.swift
@@ -60,16 +60,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     setupTransferObservers()
   }
 
-  /// Fires when the user clicks the Dock icon with no visible windows.
-  /// In this menu-bar app a Dock click without a Settings window present
-  /// has no useful default action — interpret it as "I'm done with the
-  /// Dock entry, go back to menu-bar-only." Returning `false` suppresses
-  /// any AppKit default reopen behaviour.
+  /// Fires when the user clicks the Dock icon. If a window is already
+  /// visible AppKit will bring it forward (return true). If not, the Dock
+  /// icon only exists because Settings was open recently — reopen it,
+  /// since that's the only useful action there is for this menu-bar app.
   func applicationShouldHandleReopen(
     _ sender: NSApplication, hasVisibleWindows flag: Bool
   ) -> Bool {
     if !flag {
-      NSApp.setActivationPolicy(.accessory)
+      openSettingsWindow(sender)
       return false
     }
     return true
@@ -141,7 +140,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   // MARK: - Setup Methods
 
   private func setupNotifications() {
-    NotificationManager.requestAuthorization()
+    NotificationManager.requestAuthorizationIfNeeded()
   }
 
   private func setupBluetooth() {
@@ -357,7 +356,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         switch result {
         case .success:
           self.bluetoothStore.checkActualConnectionStatusAsync { [weak self] status in
-            self?.handleSwitchAction(status: status)
+            self?.handleSwitchAction(status: status, device: targetDevice)
           }
         case .failure(let error):
           NotificationManager.showNotification(
@@ -374,7 +373,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
   }
 
-  private func handleSwitchAction(status: BluetoothPeripheralStore.ConnectionStatus) {
+  private func handleSwitchAction(
+    status: BluetoothPeripheralStore.ConnectionStatus,
+    device: NetworkDevice
+  ) {
     switch status {
     case .allConnected:
       // Show "sending" immediately on the click — feedback before the
@@ -385,7 +387,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       // can't be established, we'd otherwise disconnect locally and then
       // fail to hand peripherals over, leaving them paired nowhere.
       beginTransfer(.sending)
-      networkStore.executeCommand(.ping) { [weak self] preflight in
+      networkStore.executeCommand(.ping, on: device) { [weak self] preflight in
         guard let self = self else { return }
         switch preflight {
         case .failure(let err):
@@ -397,7 +399,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             identifier: "switch-preflight-failed"
           )
         case .success:
-          self.performHandoffToPeer()
+          self.performHandoffToPeer(device: device)
         }
       }
     case .allDisconnected:
@@ -405,7 +407,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       // `executeCommand(.unregisterAll)` *is* the preflight — if it fails,
       // nothing has changed locally yet.
       beginTransfer(.receiving)
-      networkStore.executeCommand(.unregisterAll) { [weak self] result in
+      networkStore.executeCommand(.unregisterAll, on: device) { [weak self] result in
         guard let self = self else { return }
         switch result {
         case .success:
@@ -426,7 +428,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       NotificationManager.showNotification(
         title: "Peripherals in mixed state",
         body:
-          "Some peripherals are connected to this Mac and others aren't. Open Settings → Peripheral and either connect or remove each one so they're all in the same state, then click the menu bar icon again.",
+          "Some peripherals are on this Mac, others aren't. Right-click the menu bar icon to switch each peripheral individually, then left-click to handle them all at once.",
         identifier: "switch-mixed-state"
       )
     }
@@ -436,7 +438,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   /// after a successful preflight, but the peer can still die between the
   /// preflight and `CONNECT_ALL` — if it does, re-connect peripherals
   /// locally rather than leave them stranded.
-  private func performHandoffToPeer() {
+  private func performHandoffToPeer(device: NetworkDevice) {
     bluetoothStore.peripherals.forEach { peripheral in
       bluetoothStore.unregisterFromPC(peripheral)
     }
@@ -451,7 +453,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         return
       }
-      self.networkStore.executeCommand(.connectAll) { [weak self] result in
+      self.networkStore.executeCommand(.connectAll, on: device) { [weak self] result in
         guard let self = self else { return }
         if case .failure(let err) = result {
           // Rollback: peer didn't take the peripherals, so re-pair them
@@ -494,9 +496,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       }
     }
 
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-      check()
-    }
+    // First check fires immediately — `unregisterFromPC` issues the
+    // IOBluetooth disconnect synchronously, so the device is often already
+    // disconnected by the time we get here. Falls through to the polled
+    // retry loop if not.
+    check()
   }
 
   // MARK: - Settings Management

--- a/Magic Switch/AppDelegate/Magic_SwitchApp.swift
+++ b/Magic Switch/AppDelegate/Magic_SwitchApp.swift
@@ -9,6 +9,13 @@ struct Magic_SwitchApp: App {
 
   // MARK: - Scene Configuration
 
+  /// This `Settings` scene exists only because `App.body` requires at least
+  /// one `Scene`. It is intentionally unreachable: the SwiftUI
+  /// `Settings { ... }` + `NSApp.sendAction(showSettingsWindow:)` path
+  /// silently fails to produce a visible window in this LSUIElement +
+  /// `.accessory` configuration. `AppDelegate.openSettingsWindow` hosts
+  /// `SettingsView` in a manually-built `NSWindow` instead. Do not route
+  /// back through this scene without re-reading that comment first.
   var body: some Scene {
     Settings {
       SettingsView()

--- a/Magic Switch/Manager/IncomingConnection.swift
+++ b/Magic Switch/Manager/IncomingConnection.swift
@@ -26,7 +26,11 @@ extension Notification.Name {
 final class IncomingConnection {
   // MARK: - Constants
 
+  /// Cuts off slow-talkers. Reset on every successful frame.
   private static let idleTimeout: TimeInterval = 30
+  /// Hard cap on a single connection regardless of idle activity. Without it,
+  /// a well-behaved-looking attacker could keep `idleTimer` happy with
+  /// well-formed sealed frames indefinitely and pin a listener slot forever.
   private static let totalBudget: TimeInterval = 5 * 60
 
   // MARK: - Dependencies
@@ -181,6 +185,13 @@ final class IncomingConnection {
           store.connectPeripheral(peripheral)
         }
       }
+      // Best-effort ack: OP_SUCCESS here means "command received and
+      // dispatched," not "all peripherals successfully connected." Local
+      // pair work is async and may still fail (out of range, peer never
+      // released, etc.). The peer's goal ("you now hold these") is
+      // satisfied as long as we attempt — tracking per-peripheral results
+      // and aggregating would require holding the connection open until
+      // every IOBluetooth callback lands, which isn't worth the complexity.
       sendString(DeviceCommand.operationSuccess.rawValue)
       lastReceivedCommand = nil
     case .unregisterAll:
@@ -191,6 +202,7 @@ final class IncomingConnection {
           store.unregisterFromPC(peripheral)
         }
       }
+      // See connectAll above for the best-effort-ack rationale.
       sendString(DeviceCommand.operationSuccess.rawValue)
       lastReceivedCommand = nil
     case .ping:

--- a/Magic Switch/Manager/OutgoingConnection.swift
+++ b/Magic Switch/Manager/OutgoingConnection.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Network
+import QuartzCore
 
 /// Categorised outgoing-side failure. Carries enough information for the
 /// caller to render a useful user-facing notification without needing to
@@ -10,6 +11,11 @@ enum OutgoingFailure: Error {
   case connectTimeout
   case handshakeFailed(SecureChannelError)
   case bodyFailed
+  /// Self-throttled because of recent repeated failures to this host.
+  /// Prevents a runaway retry loop from racking up failures the peer's
+  /// inbound `RateLimiter` would eventually translate into a 15-minute
+  /// block — which is much worse than briefly backing off.
+  case tooManyRecentFailures
 
   /// Short, user-facing reason. Callers prepend the device name.
   var userMessage: String {
@@ -30,6 +36,57 @@ enum OutgoingFailure: Error {
       return "Couldn't establish a secure connection."
     case .bodyFailed:
       return "The connection dropped mid-message."
+    case .tooManyRecentFailures:
+      return "Too many recent failures reaching the other Mac — backing off. Try again in a minute."
+    }
+  }
+}
+
+/// Per-host outbound failure tracker. The mirror of `RateLimiter` for the
+/// sending side: after `failureThreshold` failures inside `windowSeconds`,
+/// further attempts to that host fail fast until the window slides forward.
+/// A success clears the history immediately, so transient hiccups don't
+/// permanently inflate the counter.
+///
+/// Lives as a singleton because `OutgoingConnection` instances are
+/// short-lived (one per command); we need the counter to survive across
+/// them. `CACurrentMediaTime()` matches `RateLimiter` — wall-clock changes
+/// can't shorten the backoff.
+final class OutboundRateLimiter {
+  static let shared = OutboundRateLimiter()
+
+  private static let windowSeconds: TimeInterval = 60
+  private static let failureThreshold = 5
+
+  private let queue = DispatchQueue(label: "com.magicswitch.outbound-ratelimiter")
+  private var failuresByHost: [String: [CFTimeInterval]] = [:]
+
+  private init() {}
+
+  /// Returns true if a new attempt to `host` should proceed. Side-effect:
+  /// trims stale entries out of the failure list.
+  func shouldAttempt(host: String) -> Bool {
+    queue.sync {
+      let now = CACurrentMediaTime()
+      let recent = (failuresByHost[host] ?? []).filter { $0 > now - Self.windowSeconds }
+      failuresByHost[host] = recent.isEmpty ? nil : recent
+      return recent.count < Self.failureThreshold
+    }
+  }
+
+  func recordFailure(host: String) {
+    queue.sync {
+      let now = CACurrentMediaTime()
+      var list = failuresByHost[host, default: []]
+      list.append(now)
+      list = list.filter { $0 > now - Self.windowSeconds }
+      failuresByHost[host] = list
+    }
+  }
+
+  func recordSuccess(host: String) {
+    queue.sync {
+      failuresByHost[host] = nil
     }
   }
 }
@@ -51,7 +108,12 @@ final class OutgoingConnection {
   // MARK: - State
 
   private let connection: NWConnection
+  /// Captured separately so we can key the outbound rate limiter on it.
+  /// `NWConnection` doesn't expose the original host string in a
+  /// useful form, hence the dedicated field.
+  private let host: String
   private let pairingStore: PairingStore
+  private let rateLimiter: OutboundRateLimiter
   private let queue: DispatchQueue
   private var channel: SecureChannel?
   private var selfRef: OutgoingConnection?
@@ -65,6 +127,7 @@ final class OutgoingConnection {
     host: String,
     port: UInt16,
     pairingStore: PairingStore = .shared,
+    rateLimiter: OutboundRateLimiter = .shared,
     queue: DispatchQueue = DispatchQueue(label: "com.magicswitch.outgoing", qos: .userInitiated)
   ) {
     self.connection = NWConnection(
@@ -72,7 +135,9 @@ final class OutgoingConnection {
       port: NWEndpoint.Port(integerLiteral: port),
       using: .tcp
     )
+    self.host = host
     self.pairingStore = pairingStore
+    self.rateLimiter = rateLimiter
     self.queue = queue
   }
 
@@ -87,6 +152,13 @@ final class OutgoingConnection {
     completion: @escaping (Result<Void, OutgoingFailure>) -> Void
   ) {
     selfRef = self
+
+    guard rateLimiter.shouldAttempt(host: host) else {
+      print("OutgoingConnection: backing off — too many recent failures to \(host)")
+      completion(.failure(.tooManyRecentFailures))
+      release()
+      return
+    }
 
     guard let psk = pairingStore.currentKey() else {
       print("OutgoingConnection: not paired, aborting send")
@@ -157,6 +229,18 @@ final class OutgoingConnection {
     bodyTimer = nil
     channel?.cancel()
     connection.cancel()
+    // Feed the outbound rate limiter so a series of failures throttles
+    // future attempts, and a success clears the counter immediately. Skip
+    // `tooManyRecentFailures` — that's the limiter's own refusal and would
+    // double-count.
+    switch result {
+    case .success:
+      rateLimiter.recordSuccess(host: host)
+    case .failure(.tooManyRecentFailures):
+      break
+    case .failure:
+      rateLimiter.recordFailure(host: host)
+    }
     completion(result)
     release()
   }

--- a/Magic Switch/Manager/PairingStore.swift
+++ b/Magic Switch/Manager/PairingStore.swift
@@ -60,7 +60,15 @@ final class PairingStore: ObservableObject {
   static func generateCode() -> String {
     let alphabet = Array(codeAlphabet)
     var bytes = [UInt8](repeating: 0, count: codeLength)
-    _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+    let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+    // `SecRandomCopyBytes` failing is extremely unlikely on a healthy
+    // system, but if it did and we ignored the status we'd silently
+    // generate "AAAAAAAAAAAA" (every byte still zero) — i.e. a guessable
+    // pairing key. Crash hard instead.
+    precondition(
+      status == errSecSuccess,
+      "SecRandomCopyBytes failed with status \(status); refusing to generate a weak pairing code."
+    )
     var result = ""
     for byte in bytes {
       result.append(alphabet[Int(byte) % alphabet.count])
@@ -76,10 +84,22 @@ final class PairingStore: ObservableObject {
     return "\(String(chars[0...3]))-\(String(chars[4...7]))-\(String(chars[8...11]))"
   }
 
-  /// Normalizes free-form user input: uppercase, strip dashes/spaces.
+  /// Normalizes free-form user input: uppercase, then apply Crockford's
+  /// look-alike substitutions (I/L → 1, O → 0, U → V) so common typos of
+  /// the excluded letters resolve to the visually-similar canonical
+  /// character instead of being silently dropped. Anything still outside
+  /// the alphabet (dashes, spaces, etc.) is then filtered out.
   static func normalize(_ input: String) -> String {
     let upper = input.uppercased()
-    return upper.filter { codeAlphabet.contains($0) }
+    let substituted = upper.map { char -> Character in
+      switch char {
+      case "I", "L": return "1"
+      case "O": return "0"
+      case "U": return "V"
+      default: return char
+      }
+    }
+    return String(substituted).filter { codeAlphabet.contains($0) }
   }
 
   /// Validates that `code` is exactly `codeLength` chars in the alphabet.

--- a/Magic Switch/Manager/RateLimiter.swift
+++ b/Magic Switch/Manager/RateLimiter.swift
@@ -119,6 +119,9 @@ final class RateLimiter {
     guard case .hostPort(let host, _) = endpoint else { return "unknown" }
     switch host {
     case .ipv4(let addr):
+      // `IPv4Address`/`IPv6Address` only conform to
+      // `CustomDebugStringConvertible`; `debugDescription` is the
+      // documented printing API for them, not a debug-only helper.
       return addr.debugDescription
     case .ipv6(let addr):
       let raw = addr.debugDescription

--- a/Magic Switch/Manager/SecureChannel.swift
+++ b/Magic Switch/Manager/SecureChannel.swift
@@ -73,10 +73,14 @@ final class SecureChannel {
   func performHandshake(
     completion outerCompletion: @escaping (Result<Void, SecureChannelError>) -> Void
   ) {
-    // Single-shot latch: the timeout fires `connection.cancel()`, which then
-    // propagates to any in-flight `sendRaw`/`receiveRaw` as a connection
-    // error and triggers their own completion path. Without this, the outer
-    // completion would be invoked twice.
+    // Single-shot latch on the outer completion. The 5-second timeout fires
+    // `connection.cancel()`, which then propagates to any in-flight
+    // `sendRaw`/`receiveRaw` as a connection error and re-enters this
+    // completion path with `.connectionClosed` *after* we've already
+    // reported `.handshakeTimeout`. The race is by design — `cancel()` is
+    // the cleanest way to abort all the nested I/O — so we just absorb the
+    // duplicate via the latch instead of trying to suppress one path or the
+    // other.
     var completed = false
     let completion: (Result<Void, SecureChannelError>) -> Void = { result in
       guard !completed else { return }
@@ -85,9 +89,16 @@ final class SecureChannel {
     }
 
     var localNonce = Data(count: Self.nonceLength)
-    _ = localNonce.withUnsafeMutableBytes { buf in
+    let nonceStatus = localNonce.withUnsafeMutableBytes { buf in
       SecRandomCopyBytes(kSecRandomDefault, Self.nonceLength, buf.baseAddress!)
     }
+    // Same rationale as `PairingStore.generateCode`: if the syscall fails
+    // we'd silently negotiate a session with an all-zero nonce — replayable
+    // and predictable. Crash rather than weaken the channel.
+    precondition(
+      nonceStatus == errSecSuccess,
+      "SecRandomCopyBytes failed with status \(nonceStatus); refusing to handshake with a weak nonce."
+    )
 
     let timeoutWork = DispatchWorkItem { [weak self] in
       guard let self = self else { return }

--- a/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
+++ b/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
@@ -32,8 +32,11 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
     /// "Pairing…" before giving up. Magic peripherals typically pair within
     /// a couple of seconds; if the device is currently held by the other
     /// Mac, `IOBluetoothDevicePair.start()` has no built-in timeout and the
-    /// state would otherwise stick forever.
-    static let pairTimeout: TimeInterval = 20
+    /// state would otherwise stick forever. 60s is generous — first-time
+    /// cross-Mac handoffs (peripheral arbitrating between recently-seen
+    /// hosts) can legitimately take 30-45s, and a false-positive timeout
+    /// is worse than waiting a beat longer.
+    static let pairTimeout: TimeInterval = 60
   }
 
   // MARK: - Dependencies
@@ -143,8 +146,25 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
       btDevice.perform(Selector(("remove")))
       print("Device information removed: \(peripheral.name)")
       setConnectionState(.disconnected, for: peripheral.id)
+      return
+    }
+
+    // Fallback path: a future macOS that renames or removes the private
+    // `-remove` selector lands here. `closeConnection` doesn't fully
+    // unpair (the device stays in System Settings → Bluetooth's list), but
+    // it breaks the active session so the peer can take ownership.
+    let result = btDevice.closeConnection()
+    if result == kIOReturnSuccess {
+      print("Fell back to closeConnection() for \(peripheral.name)")
+      setConnectionState(.disconnected, for: peripheral.id)
     } else {
-      print("Failed to remove device information: \(peripheral.name)")
+      print("Failed to release \(peripheral.name): closeConnection returned \(result)")
+      NotificationManager.showNotification(
+        title: "Couldn't Release Peripheral",
+        body:
+          "Magic Switch couldn't release \(peripheral.name) from this Mac. Try Forget This Device in System Settings → Bluetooth.",
+        identifier: "unregister-failed-\(peripheral.id)"
+      )
     }
   }
 
@@ -260,7 +280,10 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
         }
       }
     }
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { check() }
+    // First check fires immediately; the IOBluetooth disconnect issued by
+    // `unregisterFromPC` is synchronous, so the peripheral is often
+    // already gone. Polled retry covers the few cases where it isn't.
+    check()
   }
 
   func connectPeripheral(_ peripheral: BluetoothPeripheral) {

--- a/Magic Switch/Model/Store/NetworkDeviceStore.swift
+++ b/Magic Switch/Model/Store/NetworkDeviceStore.swift
@@ -237,17 +237,15 @@ extension NetworkDeviceStore {
     }
   }
 
-  /// Executes a command on the first connected device through a secure channel.
+  /// Executes a command on `device` through a secure channel. The caller
+  /// must pick the target device — keeping this explicit matches the per-
+  /// peripheral senders (`executeUnregisterOne` / `executeConnectOne`) and
+  /// avoids burying the single-device assumption inside this function.
   func executeCommand(
     _ command: DeviceCommand,
+    on device: NetworkDevice,
     completion: @escaping (Result<Void, OutgoingFailure>) -> Void
   ) {
-    guard let device = networkDevices.first else {
-      print("No connected devices found")
-      completion(.failure(.connectionFailed("no registered device")))
-      return
-    }
-
     guard PairingStore.shared.isPaired else {
       completion(.failure(.notPaired))
       return
@@ -334,13 +332,18 @@ extension NetworkDeviceStore {
 }
 
 extension NetworkDeviceStore {
-  func sendPeripheralSync(peripherals: [BluetoothPeripheral], to device: NetworkDevice) {
+  /// Push this Mac's registered peripheral list to `device`. Completion
+  /// receives the categorised outgoing result so the caller can render
+  /// inline UI feedback (the Device tab does this under each row). The
+  /// store no longer surfaces its own notifications for sync — callers
+  /// decide how to report success/failure.
+  func sendPeripheralSync(
+    peripherals: [BluetoothPeripheral],
+    to device: NetworkDevice,
+    completion: ((Result<Void, OutgoingFailure>) -> Void)? = nil
+  ) {
     guard PairingStore.shared.isPaired else {
-      NotificationManager.showNotification(
-        title: "Not Paired",
-        body: "Pair this Mac first to sync the peripheral list to \(device.name).",
-        identifier: "sync-not-paired-\(device.id)"
-      )
+      completion?(.failure(.notPaired))
       return
     }
 
@@ -348,6 +351,7 @@ extension NetworkDeviceStore {
       let jsonString = String(data: data, encoding: .utf8)
     else {
       print("sendPeripheralSync: failed to encode peripherals")
+      completion?(.failure(.connectionFailed("encode failed")))
       return
     }
 
@@ -383,15 +387,7 @@ extension NetworkDeviceStore {
         }
       },
       completion: { result in
-        // Sync is a routine background-ish operation, so we stay quiet on
-        // success and only surface failures.
-        if case .failure(let err) = result {
-          NotificationManager.showNotification(
-            title: "Couldn't Sync \(device.name)",
-            body: err.userMessage,
-            identifier: "sync-failed-\(device.id)"
-          )
-        }
+        completion?(result)
       }
     )
   }

--- a/Magic Switch/View/Settings/BluetoothPeripheralSettingsView.swift
+++ b/Magic Switch/View/Settings/BluetoothPeripheralSettingsView.swift
@@ -192,15 +192,19 @@ private struct PeripheralRowView: View {
   private var connectionButton: some View {
     switch connectionState {
     case .connected:
-      Button("Remove from PC", action: primaryAction)
-        .help("Release this peripheral. If a peer Mac is paired, it'll take ownership.")
+      Button("Disconnect", action: primaryAction)
+        .help(
+          "Release this peripheral from this Mac. If a peer Mac is paired, it'll take ownership automatically."
+        )
     case .connecting:
       Button("Pairing…", action: {})
         .disabled(true)
         .help("Pairing in progress…")
     case .disconnected:
-      Button("Connect to PC", action: primaryAction)
-        .help("Pair this peripheral with your Mac. Asks the peer to release it first if needed.")
+      Button("Connect", action: primaryAction)
+        .help(
+          "Connect this peripheral to this Mac. If a peer Mac currently holds it, the peer will be asked to release it first."
+        )
     }
   }
 }

--- a/Magic Switch/View/Settings/NetworkDeviceManagementView.swift
+++ b/Magic Switch/View/Settings/NetworkDeviceManagementView.swift
@@ -1,8 +1,10 @@
 import SwiftUI
 
-/// Latest inline Ping result for a device. Carried in `pingResults` and
-/// rendered under the device row in the Registered list.
-struct PingResult {
+/// Latest inline action result for a device (Ping or Sync). Carried in
+/// `operationResults` and rendered under the device row. Either action
+/// overwrites the previous result, so there's only ever one status line
+/// per row — whichever the user did most recently.
+struct OperationResult {
   let success: Bool
   let message: String
 }
@@ -32,9 +34,17 @@ struct NetworkDeviceManagementView: View {
   // MARK: - State
 
   @State private var deviceToRemove: NetworkDevice?
-  /// Last Ping result per device id, surfaced inline because the OS-level
-  /// notification path is unreliable on ad-hoc-signed sandboxed builds.
-  @State private var pingResults: [String: PingResult] = [:]
+  /// Set when the user clicks Trust on an identity-mismatched device.
+  /// Triggers the confirmation alert below; the actual pin promotion only
+  /// happens after the user confirms.
+  @State private var deviceToTrust: NetworkDevice?
+  /// Last Ping/Sync result per device id, surfaced inline because the
+  /// OS-level notification path is unreliable on ad-hoc-signed sandboxed
+  /// builds.
+  @State private var operationResults: [String: OperationResult] = [:]
+  /// Used by `handleSyncPeripherals` to snapshot the count of peripherals
+  /// being synced for the inline success message.
+  @ObservedObject private var bluetoothStore = BluetoothPeripheralStore.shared
 
   // MARK: - View Content
 
@@ -52,9 +62,10 @@ struct NetworkDeviceManagementView: View {
 
       RegisteredDevicesSectionView(
         devices: networkStore.networkDevices,
-        pingResults: pingResults,
+        operationResults: operationResults,
         onDeviceNotify: handleDeviceNotification,
         onDeviceRemoveRequest: { deviceToRemove = $0 },
+        onSyncPeripherals: handleSyncPeripherals,
         onTrustPending: handleTrustPending
       )
 
@@ -71,6 +82,18 @@ struct NetworkDeviceManagementView: View {
         ),
         primaryButton: .destructive(Text("Remove")) {
           networkStore.removeNetworkDevice(device: device)
+        },
+        secondaryButton: .cancel()
+      )
+    }
+    .alert(item: $deviceToTrust) { device in
+      Alert(
+        title: Text("Trust new pairing key for \(device.name)?"),
+        message: Text(
+          "Only do this if you intentionally re-paired the other Mac. Otherwise this could be an impersonation attempt — the fingerprint that previously identified \(device.name) has changed."
+        ),
+        primaryButton: .destructive(Text("Trust")) {
+          networkStore.trustPendingFingerprint(for: device.id)
         },
         secondaryButton: .cancel()
       )
@@ -103,15 +126,15 @@ struct NetworkDeviceManagementView: View {
   // MARK: - Private Methods
 
   private func handleDeviceNotification(_ device: NetworkDevice) {
-    pingResults[device.id] = PingResult(success: true, message: "Pinging \(device.name)…")
+    operationResults[device.id] = OperationResult(success: true, message: "Pinging \(device.name)…")
     networkStore.sendNotification(to: device) { result in
       switch result {
       case .success:
-        pingResults[device.id] = PingResult(
+        operationResults[device.id] = OperationResult(
           success: true, message: "\(device.name) responded."
         )
       case .failure(let err):
-        pingResults[device.id] = PingResult(
+        operationResults[device.id] = OperationResult(
           success: false, message: err.userMessage
         )
       }
@@ -123,22 +146,46 @@ struct NetworkDeviceManagementView: View {
   }
 
   private func handleTrustPending(_ device: NetworkDevice) {
-    networkStore.trustPendingFingerprint(for: device.id)
+    // Request the confirmation alert; actual promotion happens in its
+    // primaryButton. TOFU pin overrides are destructive — we won't do it
+    // without explicit acknowledgement.
+    deviceToTrust = device
+  }
+
+  private func handleSyncPeripherals(_ device: NetworkDevice) {
+    let peripherals = bluetoothStore.peripherals
+    let count = peripherals.count
+    let noun = count == 1 ? "peripheral" : "peripherals"
+    operationResults[device.id] = OperationResult(
+      success: true,
+      message: "Syncing \(count) \(noun) to \(device.name)…"
+    )
+    networkStore.sendPeripheralSync(peripherals: peripherals, to: device) { result in
+      switch result {
+      case .success:
+        operationResults[device.id] = OperationResult(
+          success: true,
+          message: "Synced \(count) \(noun) to \(device.name)."
+        )
+      case .failure(let err):
+        operationResults[device.id] = OperationResult(
+          success: false,
+          message: err.userMessage
+        )
+      }
+    }
   }
 }
 
 // MARK: - Supporting Views
 
 private struct RegisteredDevicesSectionView: View {
-  // MARK: - Dependencies
-  @ObservedObject private var bluetoothStore = BluetoothPeripheralStore.shared
-  @ObservedObject private var networkStore = NetworkDeviceStore.shared
-
   // MARK: - Properties
   let devices: [NetworkDevice]
-  let pingResults: [String: PingResult]
+  let operationResults: [String: OperationResult]
   let onDeviceNotify: (NetworkDevice) -> Void
   let onDeviceRemoveRequest: (NetworkDevice) -> Void
+  let onSyncPeripherals: (NetworkDevice) -> Void
   let onTrustPending: (NetworkDevice) -> Void
 
   var body: some View {
@@ -153,15 +200,10 @@ private struct RegisteredDevicesSectionView: View {
           buttonTitle: Constants.Strings.notify,
           actionHelp: NetworkDeviceManagementView.Help.notify,
           requiresPairing: true,
-          pingResults: pingResults,
+          operationResults: operationResults,
           action: onDeviceNotify,
           onDelete: onDeviceRemoveRequest,
-          onSyncPeripherals: { device in
-            networkStore.sendPeripheralSync(
-              peripherals: bluetoothStore.peripherals,
-              to: device
-            )
-          },
+          onSyncPeripherals: onSyncPeripherals,
           onTrustPending: onTrustPending
         )
       }
@@ -222,7 +264,7 @@ private struct NetworkDeviceListView: View {
   let buttonTitle: String
   let actionHelp: String
   let requiresPairing: Bool
-  let pingResults: [String: PingResult]
+  let operationResults: [String: OperationResult]
   let action: (NetworkDevice) -> Void
   let onDelete: ((NetworkDevice) -> Void)?
   let onSyncPeripherals: ((NetworkDevice) -> Void)?
@@ -235,7 +277,7 @@ private struct NetworkDeviceListView: View {
     buttonTitle: String,
     actionHelp: String,
     requiresPairing: Bool = false,
-    pingResults: [String: PingResult] = [:],
+    operationResults: [String: OperationResult] = [:],
     action: @escaping (NetworkDevice) -> Void,
     onDelete: ((NetworkDevice) -> Void)? = nil,
     onSyncPeripherals: ((NetworkDevice) -> Void)? = nil,
@@ -245,7 +287,7 @@ private struct NetworkDeviceListView: View {
     self.buttonTitle = buttonTitle
     self.actionHelp = actionHelp
     self.requiresPairing = requiresPairing
-    self.pingResults = pingResults
+    self.operationResults = operationResults
     self.action = action
     self.onDelete = onDelete
     self.onSyncPeripherals = onSyncPeripherals
@@ -310,10 +352,10 @@ private struct NetworkDeviceListView: View {
           .padding(.vertical, 2)
         }
 
-        if let ping = pingResults[device.id] {
-          Text(ping.message)
+        if let result = operationResults[device.id] {
+          Text(result.message)
             .font(.caption)
-            .foregroundColor(ping.success ? .secondary : .red)
+            .foregroundColor(result.success ? .secondary : .red)
         }
       }
     }

--- a/Magic Switch/View/Settings/PairingSettingsView.swift
+++ b/Magic Switch/View/Settings/PairingSettingsView.swift
@@ -83,14 +83,14 @@ struct PairingSettingsView: View {
       }
       if let fingerprint = pairing.fingerprint {
         VStack(alignment: .leading, spacing: 4) {
-          Text("Fingerprint")
+          Text("Your fingerprint")
             .font(.caption)
             .foregroundColor(.secondary)
           Text(fingerprint)
             .font(.system(.title3, design: .monospaced))
         }
       }
-      Text("Verify the same fingerprint appears on your other Mac.")
+      Text("Compare with the fingerprint shown on your other Mac — they should match.")
         .foregroundColor(.secondary)
       Button("Unpair") {
         showUnpairAlert = true
@@ -137,7 +137,17 @@ private struct GenerateCodeSheet: View {
   @ObservedObject private var pairing = PairingStore.shared
   @State private var code: String = ""
   @State private var errorMessage: String?
-  @State private var isPairing = false
+  @State private var saveState: SaveState = .saving
+
+  /// Progress of the auto-save kicked off in `onAppear`. The Done button is
+  /// gated on `.saved` so the user can't dismiss with the keychain write
+  /// still in flight (which would leave us thinking we're paired before
+  /// PBKDF2 finishes).
+  private enum SaveState {
+    case saving
+    case saved
+    case failed
+  }
 
   private var formattedCode: String {
     PairingStore.formatCode(code)
@@ -160,53 +170,70 @@ private struct GenerateCodeSheet: View {
         .help("Copy the pairing code to the clipboard.")
         .accessibilityLabel("Copy pairing code")
       }
-      Text("Enter this code on your other Mac.")
-        .foregroundColor(.secondary)
-        .font(.caption)
+      Text(
+        "Enter this code on your other Mac. Order doesn't matter — both Macs derive the same key from the same code."
+      )
+      .foregroundColor(.secondary)
+      .font(.caption)
+      .multilineTextAlignment(.center)
       if let error = errorMessage {
         Text(error)
           .foregroundColor(.red)
           .font(.caption)
       }
       HStack {
-        if isPairing {
+        if saveState == .saving {
           ProgressView()
             .controlSize(.small)
+          Text("Saving…")
+            .font(.caption)
+            .foregroundColor(.secondary)
         }
         Spacer()
-        Button("Cancel") {
+        Button("Discard") {
+          discard()
+        }
+        .help("Remove the saved key from this Mac and close.")
+        Button("Done") {
           isPresented = false
         }
-        .disabled(isPairing)
-        .help("Close without saving this code.")
-        Button("I've entered this on my other Mac") {
-          startPair()
-        }
         .keyboardShortcut(.defaultAction)
-        .disabled(isPairing)
-        .help("Save this code as the pairing key on this Mac.")
+        .disabled(saveState != .saved)
+        .help("Close. The pairing key stays saved on this Mac.")
       }
     }
     .padding(24)
     .frame(width: 460)
     .onAppear {
-      code = PairingStore.generateCode()
-      errorMessage = nil
-      isPairing = false
+      generateAndSave()
     }
   }
 
-  private func startPair() {
-    isPairing = true
+  /// Generate the code and persist it immediately. This removes the failure
+  /// mode where a user generated a code, shared it with the peer, the peer
+  /// pair'd, then this side cancelled the sheet without saving — leaving
+  /// the peer paired alone and confusing the first handshake.
+  private func generateAndSave() {
+    code = PairingStore.generateCode()
     errorMessage = nil
+    saveState = .saving
     pairing.pair(withCode: code) { result in
-      isPairing = false
       switch result {
       case .success:
-        isPresented = false
+        saveState = .saved
       case .failure:
+        saveState = .failed
         errorMessage = "Failed to save pairing key."
       }
+    }
+  }
+
+  private func discard() {
+    pairing.unpair { _ in
+      // Best effort: close even if unpair returns a non-zero OSStatus. The
+      // main Pairing view's own Unpair flow surfaces keychain errors; we
+      // don't need to double up here.
+      isPresented = false
     }
   }
 }


### PR DESCRIPTION
UI/UX
- Save pairing code immediately on Generate so a Cancel after the peer pairs no longer leaves an asymmetric state; relabel to Discard/Done.
- Add destructive-confirmation alert to Trust (TOFU pin override), matching the Unpair/Remove pattern.
- Label fingerprint as "Your fingerprint" with explicit comparison copy.
- Rename "Connect to PC"/"Remove from PC" to Connect/Disconnect; tooltips describe the peer-coordination side effect.
- Surface inline Sync feedback per device row via a unified operationResults map (renamed from pingResults); sendPeripheralSync now takes an optional completion and stops surfacing its own notifications.
- Dock icon click opens Settings instead of demoting to .accessory.
- Partial-state notification points users at the right-click menu.
- Bump pairTimeout 20s -> 60s; first-time cross-Mac handoffs can legitimately take >20s while peripherals arbitrate between hosts.

Code
- Check SecRandomCopyBytes status in PairingStore.generateCode and SecureChannel.performHandshake with precondition; refuse to proceed with a weak code or nonce.
- PairingStore.normalize applies Crockford substitutions (I/L -> 1, O -> 0, U -> V) before filtering, so common typos of the excluded letters resolve correctly instead of being silently dropped.
- unregisterFromPC falls back to closeConnection if the private -remove selector is gone, with a notification if that also fails.
- Add OutboundRateLimiter (mirror of inbound RateLimiter): 5 failures in 60s -> back off; success clears the counter immediately. Wired into OutgoingConnection.run with new OutgoingFailure case.
- executeCommand takes an explicit `on device:` parameter; targetDevice threads from handleLeftClick through handleSwitchAction and performHandoffToPeer.
- Drop the unnecessary initial 0.5s sleep in waitForDisconnection and waitForLocalDisconnect — IOBluetooth disconnect is synchronous so the device is often already gone.
- requestAuthorizationIfNeeded instead of unconditional requestAuthorization at launch.
- Tombstone comment on the unreachable SwiftUI Settings scene in Magic_SwitchApp.swift; document best-effort ack semantics for connectAll/unregisterAll in IncomingConnection; expand the SecureChannel handshake-timeout race comment; comment the IncomingConnection.totalBudget rationale. Add a comment in RateLimiter.bucket explaining that .debugDescription is the documented printing API for IPv4Address/IPv6Address (only conform to CustomDebugStringConvertible) so no future reader mistakes it for a debug-only helper.

Removed the orphaned Blue Switch.xcodeproj/ directory (untracked leftover from the rename).

Build verified with xcodebuild Debug + CODE_SIGNING_ALLOWED=NO.