### PR TITLE
feat(ui): expire Ping/Sync results on tab return + raise next-step hint prominence

### DIFF
--- a/Magic Switch/View/Settings/NetworkDeviceManagementView.swift
+++ b/Magic Switch/View/Settings/NetworkDeviceManagementView.swift
@@ -52,11 +52,17 @@ struct NetworkDeviceManagementView: View {
     Form {
       if !pairing.isPaired {
         Section {
-          Text(
-            "Pair both Macs in the Pairing tab to enable Notify, Sync, and the menu-bar switch."
+          // Label + accent colour reads as "do this next" without alarming
+          // (red/yellow would imply error, which this isn't). The user is
+          // here to configure something; flag the missing prerequisite so
+          // they don't have to figure out from disabled buttons + tooltips
+          // why nothing works.
+          Label(
+            "Pair both Macs in the Pairing tab to enable Ping, Sync, and the menu-bar switch.",
+            systemImage: "arrow.right.circle.fill"
           )
-          .font(.callout)
-          .foregroundColor(.secondary)
+          .font(.callout.bold())
+          .foregroundColor(.accentColor)
         }
       }
 
@@ -74,6 +80,12 @@ struct NetworkDeviceManagementView: View {
         onDeviceRegister: handleDeviceRegistration
       )
     }
+    // Clear stale Ping/Sync results whenever the user comes back to this
+    // tab (or first opens it). Keeps "<device> responded." / failure lines
+    // from sticking around across Settings sessions when they're no longer
+    // meaningful. Within a single tab visit, repeated actions still
+    // overwrite each other (existing behaviour, unchanged).
+    .onAppear { operationResults.removeAll() }
     .alert(item: $deviceToRemove) { device in
       Alert(
         title: Text("Remove \(device.name)?"),

--- a/Magic Switch/View/Settings/PairingSettingsView.swift
+++ b/Magic Switch/View/Settings/PairingSettingsView.swift
@@ -77,9 +77,15 @@ struct PairingSettingsView: View {
         .font(.title2)
         .bold()
       if networkStore.networkDevices.isEmpty {
-        Text("Now pick the other Mac in Settings → Device to start switching.")
-          .font(.callout)
-          .foregroundColor(.secondary)
+        // Mirrors the prerequisite hint on the Device tab — accent-coloured
+        // Label so the "do this next" affordance reads as actionable
+        // instead of looking like throwaway helper text.
+        Label(
+          "Now pick the other Mac in Settings → Device to start switching.",
+          systemImage: "arrow.right.circle.fill"
+        )
+        .font(.callout.bold())
+        .foregroundColor(.accentColor)
       }
       if let fingerprint = pairing.fingerprint {
         VStack(alignment: .leading, spacing: 4) {


### PR DESCRIPTION
Two follow-up polish items to finish the work landed in the prior pass:

- The inline Ping/Sync result ("<peer> responded." / "Synced 3 peripherals to …" / failure reasons) was pinned forever — there was no path to clearing it short of closing Settings entirely. `.onAppear` on the Device tab form now wipes `operationResults` whenever the tab is shown, which covers both "user switched away and came back" and "Settings was reopened later." Repeated actions within a single tab visit still overwrite each other (existing behaviour, unchanged).

- The "next step" hints in the Device and Pairing tabs were styled with `.foregroundColor(.secondary)` — same colour as plain helper text, so they didn't visually signal "act here." Bumped to `Label(..., systemImage: "arrow.right.circle.fill")` with `.font(.callout.bold())` and `.foregroundColor(.accentColor)`. The arrow icon + system accent colour reads as "do this next" without alarming (red/yellow would imply error, which this isn't).

Also caught a stale string while I was in there: the Device tab hint still said "Notify" — corrected to "Ping" to match the button label.

Ports the unmerged 47b1cb6 from the peripheral-refresh-and-ux-polish branch (pre-rename `Blue Switch/...` paths) onto the current `Magic Switch/...` layout.