### PR TITLE
feat: check GitHub for a newer release and surface it

### DIFF
--- a/Magic Switch.xcodeproj/project.pbxproj
+++ b/Magic Switch.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		0A00001000000000000000B3 /* IncomingConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00001000000000000000A3 /* IncomingConnection.swift */; };
 		0A00001000000000000000B4 /* OutgoingConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00001000000000000000A4 /* OutgoingConnection.swift */; };
 		0A00001000000000000000B5 /* RateLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00001000000000000000A5 /* RateLimiter.swift */; };
+		0A00002000000000000000B6 /* UpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00002000000000000000A6 /* UpdateChecker.swift */; };
 		0A00001000000000000000B6 /* PairingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00001000000000000000A6 /* PairingSettingsView.swift */; };
 		076AB2202CE9D690004D45F0 /* BluetoothPeripheral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076AB2002CE9D690004D45F0 /* BluetoothPeripheral.swift */; };
 		076AB2212CE9D690004D45F0 /* NetworkDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076AB2012CE9D690004D45F0 /* NetworkDevice.swift */; };
@@ -48,6 +49,7 @@
 		0A00001000000000000000A3 /* IncomingConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncomingConnection.swift; sourceTree = "<group>"; };
 		0A00001000000000000000A4 /* OutgoingConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutgoingConnection.swift; sourceTree = "<group>"; };
 		0A00001000000000000000A5 /* RateLimiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RateLimiter.swift; sourceTree = "<group>"; };
+		0A00002000000000000000A6 /* UpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateChecker.swift; sourceTree = "<group>"; };
 		0A00001000000000000000A6 /* PairingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingSettingsView.swift; sourceTree = "<group>"; };
 		076AB2002CE9D690004D45F0 /* BluetoothPeripheral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothPeripheral.swift; sourceTree = "<group>"; };
 		076AB2012CE9D690004D45F0 /* NetworkDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDevice.swift; sourceTree = "<group>"; };
@@ -106,6 +108,7 @@
 				0A00001000000000000000A3 /* IncomingConnection.swift */,
 				0A00001000000000000000A4 /* OutgoingConnection.swift */,
 				0A00001000000000000000A5 /* RateLimiter.swift */,
+				0A00002000000000000000A6 /* UpdateChecker.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -294,6 +297,7 @@
 				0A00001000000000000000B3 /* IncomingConnection.swift in Sources */,
 				0A00001000000000000000B4 /* OutgoingConnection.swift in Sources */,
 				0A00001000000000000000B5 /* RateLimiter.swift in Sources */,
+				0A00002000000000000000B6 /* UpdateChecker.swift in Sources */,
 				0A00001000000000000000B6 /* PairingSettingsView.swift in Sources */,
 				076AB2202CE9D690004D45F0 /* BluetoothPeripheral.swift in Sources */,
 				076AB2212CE9D690004D45F0 /* NetworkDevice.swift in Sources */,

--- a/Magic Switch/AppDelegate/AppDelegate.swift
+++ b/Magic Switch/AppDelegate/AppDelegate.swift
@@ -58,6 +58,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     setupActivationPolicyTracking()
     setupPingFlashObserver()
     setupTransferObservers()
+    // Best-effort, silent, throttled to once per 24h. Drives the "Update
+    // Available" affordances in the right-click menu and Settings → Other.
+    UpdateChecker.shared.checkIfNeeded()
   }
 
   /// Fires when the user clicks the Dock icon. If a window is already
@@ -534,6 +537,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
   /// Tag of the Device tab in `SettingsView`. Keep in sync if tabs reorder.
   private static let deviceTabIndex = 1
+
+  /// Opens the newest release in the default browser. Wired to the "Update
+  /// Available" item in the right-click menu (see `MenuBarView`).
+  @objc func openLatestReleasePage(_ sender: Any?) {
+    guard let url = UpdateChecker.shared.releasePageURL else { return }
+    NSWorkspace.shared.open(url)
+  }
 
   /// Observes `.magicSwitchReceivedPing` (posted by `IncomingConnection`
   /// when this Mac handles a `.notification` command) and flashes the

--- a/Magic Switch/Manager/UpdateChecker.swift
+++ b/Magic Switch/Manager/UpdateChecker.swift
@@ -1,0 +1,162 @@
+import Combine
+import Foundation
+
+/// Best-effort check for a newer published release on GitHub.
+///
+/// Magic Switch ships via semantic-release, which publishes one GitHub Release
+/// per `vX.Y.Z` tag, so `releases/latest` is the canonical "newest stable
+/// version" — a single unauthenticated request, no pagination. The check is
+/// silent: any network/parse failure leaves the last known state untouched and
+/// is never surfaced to the user. We hit the network at most once per 24h
+/// (persisted in `UserDefaults`) so a menu-bar process that runs for days
+/// doesn't poll GitHub on a loop. Results drive the right-click menu and the
+/// Settings → Other tab; we never auto-update, just link to the release page.
+final class UpdateChecker: ObservableObject {
+  // MARK: - Singleton
+
+  static let shared = UpdateChecker()
+
+  // MARK: - Constants
+
+  private enum Constants {
+    /// Owner/repo whose published Releases define the latest version. Casing
+    /// matches the existing GitHub links elsewhere in the app; GitHub treats
+    /// owner/repo case-insensitively regardless.
+    static let repoSlug = "MegaManSec/magic-switch"
+    /// `releases/latest` resolves to the most recent non-draft, non-prerelease
+    /// release — exactly what semantic-release publishes.
+    static let latestReleaseAPI = "https://api.github.com/repos/\(repoSlug)/releases/latest"
+    /// Browser page the menu / Settings open. `/releases/latest` redirects to
+    /// the newest release, so it's correct without parsing anything.
+    static let latestReleasePage = "https://github.com/\(repoSlug)/releases/latest"
+    /// GitHub's API rejects requests without a User-Agent (403).
+    static let userAgent = "Magic-Switch"
+    static let checkInterval: TimeInterval = 24 * 60 * 60
+    static let requestTimeout: TimeInterval = 10
+    /// Persisted state, namespaced like the rest of the app's UserDefaults keys.
+    static let lastCheckedKey = "com.magicswitch.updatecheck.lastChecked"
+    static let latestVersionKey = "com.magicswitch.updatecheck.latestVersion"
+  }
+
+  // MARK: - Published State
+
+  /// Newest version advertised by GitHub (e.g. "2.4.0"), or nil if we've never
+  /// fetched one successfully. Mutated on main only.
+  @Published private(set) var latestVersion: String?
+
+  // MARK: - Properties
+
+  /// Browser URL for the latest release. `nil` only if the constant is ever
+  /// malformed; callers guard on it.
+  let releasePageURL = URL(string: Constants.latestReleasePage)
+
+  /// Guards against overlapping in-flight checks within a session (e.g. the
+  /// user reopening Settings repeatedly). Main-thread only.
+  private var isChecking = false
+
+  // MARK: - Computed Properties
+
+  /// The running app's marketing version, e.g. "2.3.1". Debug builds report
+  /// the placeholder "0.0.0" (semantic-release patches `MARKETING_VERSION`
+  /// only in CI), which is one reason the check is suppressed in `#if DEBUG`.
+  var currentVersion: String {
+    Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.0.0"
+  }
+
+  /// True when GitHub advertises a strictly-greater semantic version.
+  var updateAvailable: Bool {
+    guard let latest = latestVersion else { return false }
+    return Self.isNewer(latest, than: currentVersion)
+  }
+
+  // MARK: - Initialization
+
+  private init() {
+    // Surface the cached result immediately so the menu / Settings reflect the
+    // last successful check without waiting for a network round trip.
+    latestVersion = UserDefaults.standard.string(forKey: Constants.latestVersionKey)
+  }
+
+  // MARK: - Public Methods
+
+  /// Fetch the latest release if it's been at least 24h since the last
+  /// successful check. Returns immediately; `latestVersion` updates
+  /// asynchronously on success. Call from the main thread (app launch, view
+  /// `onAppear`).
+  func checkIfNeeded() {
+    guard !isChecking else { return }
+    if let last = UserDefaults.standard.object(forKey: Constants.lastCheckedKey) as? Date,
+      Date().timeIntervalSince(last) < Constants.checkInterval
+    {
+      return
+    }
+    check()
+  }
+
+  // MARK: - Private Methods
+
+  private func check() {
+    #if DEBUG
+      // Don't nag during development — a dev build's version is the "0.0.0"
+      // placeholder, so every release would look newer. Mirrors
+      // exodus-deps-tui suppressing the check when run from a source checkout.
+      return
+    #else
+      guard let url = URL(string: Constants.latestReleaseAPI) else { return }
+      isChecking = true
+
+      var request = URLRequest(url: url)
+      request.timeoutInterval = Constants.requestTimeout
+      request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+      request.setValue("2022-11-28", forHTTPHeaderField: "X-GitHub-Api-Version")
+      request.setValue(Constants.userAgent, forHTTPHeaderField: "User-Agent")
+
+      URLSession.shared.dataTask(with: request) { [weak self] data, response, _ in
+        let version: String? = {
+          guard let http = response as? HTTPURLResponse, http.statusCode == 200,
+            let data = data, let tag = Self.parseTagName(from: data)
+          else { return nil }
+          return Self.normalize(tag)
+        }()
+
+        DispatchQueue.main.async {
+          guard let self = self else { return }
+          self.isChecking = false
+          // Only record success: a transient failure shouldn't suppress the
+          // next launch's retry for a full 24h.
+          guard let version = version else { return }
+          UserDefaults.standard.set(Date(), forKey: Constants.lastCheckedKey)
+          UserDefaults.standard.set(version, forKey: Constants.latestVersionKey)
+          self.latestVersion = version
+        }
+      }.resume()
+    #endif
+  }
+
+  /// Pull `tag_name` out of the `releases/latest` JSON without a model type.
+  private static func parseTagName(from data: Data) -> String? {
+    guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+      let tag = obj["tag_name"] as? String
+    else { return nil }
+    return tag
+  }
+
+  /// Strip a leading "v" so a `vX.Y.Z` tag compares against the bare
+  /// `CFBundleShortVersionString`.
+  private static func normalize(_ tag: String) -> String {
+    tag.hasPrefix("v") ? String(tag.dropFirst()) : tag
+  }
+
+  /// Numeric per-component semver compare. Missing/non-numeric components are
+  /// treated as 0, so "2.4" < "2.4.1" and a longer prefix-equal version wins.
+  static func isNewer(_ a: String, than b: String) -> Bool {
+    let pa = a.split(separator: ".").map { Int($0) ?? 0 }
+    let pb = b.split(separator: ".").map { Int($0) ?? 0 }
+    for i in 0..<max(pa.count, pb.count) {
+      let x = i < pa.count ? pa[i] : 0
+      let y = i < pb.count ? pb[i] : 0
+      if x != y { return x > y }
+    }
+    return false
+  }
+}

--- a/Magic Switch/Manager/UpdateChecker.swift
+++ b/Magic Switch/Manager/UpdateChecker.swift
@@ -7,10 +7,12 @@ import Foundation
 /// per `vX.Y.Z` tag, so `releases/latest` is the canonical "newest stable
 /// version" — a single unauthenticated request, no pagination. The check is
 /// silent: any network/parse failure leaves the last known state untouched and
-/// is never surfaced to the user. We hit the network at most once per 24h
-/// (persisted in `UserDefaults`) so a menu-bar process that runs for days
-/// doesn't poll GitHub on a loop. Results drive the right-click menu and the
-/// Settings → Other tab; we never auto-update, just link to the release page.
+/// is never surfaced to the user. An hourly timer re-evaluates a 24h gate
+/// (both persisted in `UserDefaults`), so the network is hit at most once per
+/// day, while a transient failure — which doesn't advance the gate — is retried
+/// on the next tick instead of waiting for a relaunch. Results drive the
+/// right-click menu and the Settings → Other tab; we never auto-update, just
+/// link to the release page.
 final class UpdateChecker: ObservableObject {
   // MARK: - Singleton
 
@@ -32,6 +34,9 @@ final class UpdateChecker: ObservableObject {
     /// GitHub's API rejects requests without a User-Agent (403).
     static let userAgent = "Magic-Switch"
     static let checkInterval: TimeInterval = 24 * 60 * 60
+    /// Timer cadence. Each tick just re-checks the 24h gate, so it rarely fires
+    /// a real request; it mainly bounds how soon a failed check is retried.
+    static let pollInterval: TimeInterval = 60 * 60
     static let requestTimeout: TimeInterval = 10
     /// Persisted state, namespaced like the rest of the app's UserDefaults keys.
     static let lastCheckedKey = "com.magicswitch.updatecheck.lastChecked"
@@ -54,6 +59,10 @@ final class UpdateChecker: ObservableObject {
   /// user reopening Settings repeatedly). Main-thread only.
   private var isChecking = false
 
+  /// Hourly poll, retained for the singleton's lifetime, so a long-running app
+  /// re-checks (and retries failures) without needing a relaunch.
+  private var pollTimer: DispatchSourceTimer?
+
   // MARK: - Computed Properties
 
   /// The running app's marketing version, e.g. "2.3.1". Debug builds report
@@ -75,14 +84,27 @@ final class UpdateChecker: ObservableObject {
     // Surface the cached result immediately so the menu / Settings reflect the
     // last successful check without waiting for a network round trip.
     latestVersion = UserDefaults.standard.string(forKey: Constants.latestVersionKey)
+    startPolling()
+  }
+
+  /// Tick hourly and let `checkIfNeeded` decide whether the 24h gate has
+  /// opened. A failed attempt doesn't advance the gate, so a transient error
+  /// self-heals on the next tick (~1h) instead of waiting for a relaunch. The
+  /// first tick is one interval out — app launch does the immediate check.
+  private func startPolling() {
+    let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.main)
+    timer.schedule(deadline: .now() + Constants.pollInterval, repeating: Constants.pollInterval)
+    timer.setEventHandler { [weak self] in self?.checkIfNeeded() }
+    timer.resume()
+    pollTimer = timer
   }
 
   // MARK: - Public Methods
 
   /// Fetch the latest release if it's been at least 24h since the last
   /// successful check. Returns immediately; `latestVersion` updates
-  /// asynchronously on success. Call from the main thread (app launch, view
-  /// `onAppear`).
+  /// asynchronously on success. Called on the main thread from app launch, the
+  /// Settings `onAppear`, and the hourly `pollTimer`.
   func checkIfNeeded() {
     guard !isChecking else { return }
     if let last = UserDefaults.standard.object(forKey: Constants.lastCheckedKey) as? Date,

--- a/Magic Switch/View/MenuBar/MenuBarView.swift
+++ b/Magic Switch/View/MenuBar/MenuBarView.swift
@@ -9,6 +9,7 @@ final class MenuBarView: MenuBarPresentable {
 
   private enum Constants {
     enum Menu {
+      static let updateAvailable = "Update Available"
       static let macsHeader = "Macs"
       static let peripheralsHeader = "Peripherals"
       static let settings = "Settings..."
@@ -21,6 +22,7 @@ final class MenuBarView: MenuBarPresentable {
     }
 
     enum Symbols {
+      static let update = "arrow.down.circle.fill"
       static let mac = "desktopcomputer"
       static let peripheral = "keyboard"
       static let settings = "gearshape"
@@ -32,6 +34,7 @@ final class MenuBarView: MenuBarPresentable {
 
   private let networkStore = NetworkDeviceStore.shared
   private let bluetoothStore = BluetoothPeripheralStore.shared
+  private let updateChecker = UpdateChecker.shared
 
   // MARK: - Public Methods
 
@@ -44,6 +47,19 @@ final class MenuBarView: MenuBarPresentable {
 
   private func createMenu() -> NSMenu {
     let menu = NSMenu()
+
+    // Surface an available update at the very top — the most visible spot.
+    // Clicking opens the release page in the browser; nothing destructive, so
+    // it stays enabled (no `validateMenuItem` arm needed).
+    if updateChecker.updateAvailable, let latest = updateChecker.latestVersion {
+      let update = makeItem(
+        title: "\(Constants.Menu.updateAvailable): v\(latest)",
+        symbol: Constants.Symbols.update,
+        action: #selector(AppDelegate.openLatestReleasePage(_:)))
+      update.toolTip = "A newer version of Magic Switch is available. Opens the release page."
+      menu.addItem(update)
+      menu.addItem(.separator())
+    }
 
     let macs = networkStore.networkDevices
     if !macs.isEmpty {

--- a/Magic Switch/View/Settings/OtherSettingsView.swift
+++ b/Magic Switch/View/Settings/OtherSettingsView.swift
@@ -6,6 +6,7 @@ struct OtherSettingsView: View {
   // MARK: - Properties
 
   @Environment(\.openURL) private var openURL
+  @ObservedObject private var updateChecker = UpdateChecker.shared
   @State private var launchAtLogin: Bool = false
 
   // MARK: - View Content
@@ -27,8 +28,24 @@ struct OtherSettingsView: View {
           action: showLicenseInfo
         )
       }
+      Section {
+        if updateChecker.updateAvailable, let latest = updateChecker.latestVersion {
+          SettingsRowView(
+            title: "Update Available — v\(latest)",
+            help:
+              "A newer version of Magic Switch is available. Opens the release page in your browser.",
+            action: openLatestRelease
+          )
+        }
+        HStack {
+          Text("Version")
+          Spacer()
+          Text(updateChecker.currentVersion)
+            .foregroundColor(.secondary)
+        }
+      }
     }
-    .onAppear(perform: refreshLaunchAtLogin)
+    .onAppear(perform: refreshOnAppear)
   }
 
   var body: some View {
@@ -47,6 +64,18 @@ struct OtherSettingsView: View {
     guard let url = URL(string: "https://github.com/MegaManSec/magic-switch/blob/main/LICENSE")
     else { return }
     openURL(url)
+  }
+
+  private func openLatestRelease() {
+    guard let url = updateChecker.releasePageURL else { return }
+    openURL(url)
+  }
+
+  /// Refresh launch-at-login state and nudge the update check. `checkIfNeeded`
+  /// respects the 24h cadence, so opening Settings rarely fires a real request.
+  private func refreshOnAppear() {
+    refreshLaunchAtLogin()
+    updateChecker.checkIfNeeded()
   }
 
   private func refreshLaunchAtLogin() {


### PR DESCRIPTION
## What

Adds an in-app update check. Magic Switch now polls GitHub for the latest published release and, when a newer version exists, surfaces it in two places — both of which open the release page in the default browser.

## Why

There's currently no signal that a newer build exists. The app ships via semantic-release (one GitHub Release per `vX.Y.Z` tag), so `releases/latest` is a reliable source of truth. Modeled on `exodus-deps-tui`'s update check, using only its GitHub path.

## How it works

- **`Manager/UpdateChecker.swift`** — `ObservableObject` singleton.
  - `GET /repos/MegaManSec/magic-switch/releases/latest` — unauthenticated; sends `User-Agent`/`Accept`/`X-GitHub-Api-Version`; 10s timeout. Uses the existing `network.client` entitlement — no new permissions, no token.
  - **Throttled to once / 24h** (persisted in `UserDefaults`); only a *successful* check advances the timestamp, so being offline doesn't suppress retries for a full day.
  - **Fail-silent** — any network/parse error leaves prior state untouched and is never shown.
  - **Suppressed in `#if DEBUG`** — dev builds carry the `0.0.0` `MARKETING_VERSION` placeholder (semantic-release only patches it in CI), which would otherwise flag every release as "newer."
  - Numeric per-component semver compare vs. `CFBundleShortVersionString`.
- **Right-click menu** — an "Update Available: vX.Y.Z" item at the top.
- **Settings → Other** — a "Version" row, plus a conditional "Update Available — vX.Y.Z" row.
- Never auto-updates; both surfaces just open the release page.

## Testing

- `xcodebuild` Debug build succeeds.
- Pure logic (semver compare, `v`-strip, `tag_name` JSON parse) verified via standalone checks (14/14 pass).
- Live endpoint confirmed: `releases/latest` → `200`, `tag_name: v2.5.0`, `draft/prerelease: false`.

## Note

The local git remote still uses the old `blue-switch` name (GitHub 301-redirects it to `magic-switch`); this check targets the canonical `MegaManSec/magic-switch`.