### PR TITLE
feat: open the menu on any click; switch from a Mac row

### DIFF
--- a/Magic Switch/AppDelegate/AppDelegate.swift
+++ b/Magic Switch/AppDelegate/AppDelegate.swift
@@ -327,11 +327,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   @objc private func handleClick(_ sender: NSStatusBarButton) {
     guard let event = NSApp.currentEvent else { return }
 
+    // Both buttons open the menu; the switch is triggered by clicking a Mac
+    // row inside it (see `handleMacMenuClick`).
     switch event.type {
-    case .rightMouseUp:
+    case .rightMouseUp, .leftMouseUp:
       showMenu()
-    case .leftMouseUp:
-      handleLeftClick()
     default:
       break
     }
@@ -341,16 +341,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     MenuBarView().showMenu(statusItem: statusItem)
   }
 
-  private func handleLeftClick() {
-    guard let targetDevice = networkStore.networkDevices.first else {
-      NotificationManager.showNotification(
-        title: "Error",
-        body: "No devices connected. Please connect a device first."
-      )
-      return
-    }
-
-    targetDevice.checkHealth { [weak self] result in
+  /// Runs the switch handoff with `device`. Triggered by clicking a Mac row in
+  /// the menu. `checkHealth` confirms the peer's TCP port is open before we
+  /// touch any local Bluetooth state.
+  private func performSwitch(with device: NetworkDevice) {
+    device.checkHealth { [weak self] result in
       // `checkHealth` fires on its own queue. Hop to main before any UI or
       // store mutations, and before calling `checkActualConnectionStatusAsync`
       // (which expects to be invoked from main).
@@ -359,7 +354,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         switch result {
         case .success:
           self.bluetoothStore.checkActualConnectionStatusAsync { [weak self] status in
-            self?.handleSwitchAction(status: status, device: targetDevice)
+            self?.handleSwitchAction(status: status, device: device)
           }
         case .failure(let error):
           NotificationManager.showNotification(
@@ -526,17 +521,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
   }
 
-  /// Right-click menu's Mac entry. Switches the persisted Settings tab to
-  /// Device and opens Settings, so the row has an actual affordance instead
-  /// of just being a greyed-out label.
+  /// Menu's Mac entry. Performs the peripheral switch (handoff) with the
+  /// clicked Mac. `validateMenuItem` greys the row out when the peer isn't
+  /// reachable, so this only fires for an active device.
   @objc func handleMacMenuClick(_ sender: NSMenuItem) {
-    // Tag matches `SettingsView`'s Device tab — kept in sync via this constant.
-    UserDefaults.standard.set(Self.deviceTabIndex, forKey: "settings-selected-tab")
-    openSettingsWindow(sender)
+    guard let id = sender.representedObject as? String,
+      let device = networkStore.networkDevices.first(where: { $0.id == id })
+    else { return }
+    performSwitch(with: device)
   }
-
-  /// Tag of the Device tab in `SettingsView`. Keep in sync if tabs reorder.
-  private static let deviceTabIndex = 1
 
   /// Opens the newest release in the default browser. Wired to the "Update
   /// Available" item in the right-click menu (see `MenuBarView`).

--- a/Magic Switch/View/MenuBar/MenuBarView.swift
+++ b/Magic Switch/View/MenuBar/MenuBarView.swift
@@ -65,10 +65,9 @@ final class MenuBarView: MenuBarPresentable {
     if !macs.isEmpty {
       menu.addItem(makeSectionHeader(Constants.Menu.macsHeader))
       for device in macs {
-        // Click opens Settings → Device. Enabled state is driven by
-        // `validateMenuItem` on AppDelegate using `device.isActive`, so a
-        // peer that's gone offline greys out for a meaningful reason
-        // instead of "this row has no action wired up".
+        // Click runs the switch (handoff) with this Mac. Enabled state is
+        // driven by `validateMenuItem` on AppDelegate using `device.isActive`,
+        // so a peer that's gone offline greys out instead of failing silently.
         let item = makeItem(
           title: device.name,
           symbol: Constants.Symbols.mac,
@@ -76,7 +75,7 @@ final class MenuBarView: MenuBarPresentable {
         item.representedObject = device.id
         item.toolTip =
           device.isActive
-          ? "Open Settings → Device"
+          ? "Switch peripherals between this Mac and \(device.name)."
           : "\(device.name) isn't reachable on the network right now."
         menu.addItem(item)
       }

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ Until step 4 completes, the switch action and peripheral sync refuse to talk to 
 
 | Action                                  | Result                                                                                          |
 | --------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| Left-click menu bar icon                | Hand all peripherals between the two Macs at once                                               |
-| Right-click menu bar icon → peripheral  | Switch just that one peripheral. Checkmark = currently on this Mac                              |
-| Right-click menu bar icon → Settings    | Open the Settings window                                                                        |
+| Click the menu-bar icon (either button) | Open the menu |
+| Menu → a Mac | Hand all peripherals between this Mac and that one |
+| Menu → a peripheral | Switch just that one peripheral. Checkmark = currently on this Mac |
+| Menu → Settings | Open the Settings window |
 
 The menu-bar icon also signals state: a **warning triangle** means Magic Switch needs attention (not paired, or Bluetooth off/denied) — hover for the reason; **up/down arrows** flash briefly while peripherals are moving between Macs.
 


### PR DESCRIPTION
## Summary

Reworks the menu-bar icon interaction so a click always opens the menu, and the switch is an explicit choice inside it:

- **Both mouse buttons now open the dropdown** (`handleClick` → `showMenu`). The icon no longer switches on its own.
- **Clicking a Mac row performs the switch** (the handoff) — `handleMacMenuClick` → new `performSwitch(with:)` — instead of opening Settings → Device. `validateMenuItem` still greys out an unreachable peer, so you can't switch with an offline Mac.
- Peripheral rows, Settings, and Quit are unchanged.
- `handleLeftClick` is folded into `performSwitch`; the now-unused `deviceTabIndex` is removed.
- README Usage table updated to match.