### PR TITLE
feat: release held peripherals on sleep, reclaim on wake

### DIFF
--- a/Magic Switch.xcodeproj/project.pbxproj
+++ b/Magic Switch.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		076AB21D2CE9D690004D45F0 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076AB1FC2CE9D690004D45F0 /* NotificationManager.swift */; };
 		076AB21E2CE9D690004D45F0 /* ServiceBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076AB1FD2CE9D690004D45F0 /* ServiceBrowser.swift */; };
 		076AB21F2CE9D690004D45F0 /* ServicePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076AB1FE2CE9D690004D45F0 /* ServicePublisher.swift */; };
+		0A00003000000000000000B7 /* SleepMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00003000000000000000A7 /* SleepMonitor.swift */; };
 		0A00001000000000000000B1 /* SecureChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00001000000000000000A1 /* SecureChannel.swift */; };
 		0A00001000000000000000B2 /* PairingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00001000000000000000A2 /* PairingStore.swift */; };
 		0A00001000000000000000B3 /* IncomingConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00001000000000000000A3 /* IncomingConnection.swift */; };
@@ -44,6 +45,7 @@
 		076AB1FC2CE9D690004D45F0 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		076AB1FD2CE9D690004D45F0 /* ServiceBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceBrowser.swift; sourceTree = "<group>"; };
 		076AB1FE2CE9D690004D45F0 /* ServicePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServicePublisher.swift; sourceTree = "<group>"; };
+		0A00003000000000000000A7 /* SleepMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepMonitor.swift; sourceTree = "<group>"; };
 		0A00001000000000000000A1 /* SecureChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureChannel.swift; sourceTree = "<group>"; };
 		0A00001000000000000000A2 /* PairingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingStore.swift; sourceTree = "<group>"; };
 		0A00001000000000000000A3 /* IncomingConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncomingConnection.swift; sourceTree = "<group>"; };
@@ -103,6 +105,7 @@
 				076AB1FC2CE9D690004D45F0 /* NotificationManager.swift */,
 				076AB1FD2CE9D690004D45F0 /* ServiceBrowser.swift */,
 				076AB1FE2CE9D690004D45F0 /* ServicePublisher.swift */,
+				0A00003000000000000000A7 /* SleepMonitor.swift */,
 				0A00001000000000000000A1 /* SecureChannel.swift */,
 				0A00001000000000000000A2 /* PairingStore.swift */,
 				0A00001000000000000000A3 /* IncomingConnection.swift */,
@@ -292,6 +295,7 @@
 				076AB21D2CE9D690004D45F0 /* NotificationManager.swift in Sources */,
 				076AB21E2CE9D690004D45F0 /* ServiceBrowser.swift in Sources */,
 				076AB21F2CE9D690004D45F0 /* ServicePublisher.swift in Sources */,
+				0A00003000000000000000B7 /* SleepMonitor.swift in Sources */,
 				0A00001000000000000000B1 /* SecureChannel.swift in Sources */,
 				0A00001000000000000000B2 /* PairingStore.swift in Sources */,
 				0A00001000000000000000B3 /* IncomingConnection.swift in Sources */,

--- a/Magic Switch/Manager/IncomingConnection.swift
+++ b/Magic Switch/Manager/IncomingConnection.swift
@@ -174,7 +174,7 @@ final class IncomingConnection {
   private func handleCommand(_ command: DeviceCommand) {
     lastReceivedCommand = command
     switch command {
-    case .notification, .syncPeripherals, .unregisterOne, .connectOne:
+    case .notification, .syncPeripherals, .unregisterOne, .connectOne, .holdsOne:
       // Two-frame commands; data frame handled in `handleCommandData`.
       break
     case .connectAll:
@@ -286,6 +286,24 @@ final class IncomingConnection {
         }
       }
       sendString(DeviceCommand.operationSuccess.rawValue)
+    case .holdsOne:
+      guard Self.isValidMACAddress(message) else {
+        print("holdsOne: invalid MAC address: \(message)")
+        sendString(DeviceCommand.operationFailed.rawValue)
+        break
+      }
+      // Read-only query: OP_SUCCESS only if we have a live connection to it,
+      // so the peer's wake-time reclaim won't grab a peripheral we're using.
+      // The BT check completes on the Bluetooth queue; hop back to the
+      // connection queue so all sealed sends stay serialized there (the send
+      // counter isn't synchronized across queues).
+      bluetoothStore.isHoldingPeripheral(address: message) { [weak self] held in
+        guard let self = self else { return }
+        self.queue.async {
+          self.sendString(
+            (held ? DeviceCommand.operationSuccess : DeviceCommand.operationFailed).rawValue)
+        }
+      }
     default:
       break
     }

--- a/Magic Switch/Manager/SleepMonitor.swift
+++ b/Magic Switch/Manager/SleepMonitor.swift
@@ -1,0 +1,93 @@
+import Foundation
+import IOKit
+import IOKit.pwr_mgt
+
+/// IOKit power message types from `<IOKit/IOMessage.h>`. They're defined there
+/// via the `iokit_common_msg` macro (`sys_iokit | sub_iokit_common | msg`,
+/// with `sys_iokit == 0xe0000000`), which the Swift importer can't evaluate —
+/// so the symbols aren't visible in Swift and we hardcode the resolved values.
+private let kIOMessageCanSystemSleep: UInt32 = 0xe000_0270
+private let kIOMessageSystemWillSleep: UInt32 = 0xe000_0280
+private let kIOMessageSystemHasPoweredOn: UInt32 = 0xe000_0300
+
+/// Fires `onWillSleep` immediately before the system sleeps and holds off the
+/// power transition until the handler returns, so brief teardown work (here,
+/// releasing the Magic peripherals this Mac is holding) lands before the
+/// Bluetooth radio powers down.
+///
+/// Uses `IORegisterForSystemPower` rather than
+/// `NSWorkspace.willSleepNotification` on purpose: only the IOKit path lets us
+/// delay the acknowledgement until our work is done. The notification path
+/// fires and the system proceeds to sleep regardless, which would race the
+/// unpair against the radio power-down — exactly what we can't afford, since
+/// the whole point is that a peer can't ask a sleeping Mac to release later.
+final class SleepMonitor {
+  /// Called on the main run loop just before sleep. The system is blocked
+  /// until it returns (subject to the OS's ~30s power-handler watchdog), so
+  /// keep it fast.
+  var onWillSleep: (() -> Void)?
+
+  /// Called on the main run loop after the system wakes. Not blocking — used
+  /// to reclaim peripherals released for sleep that the peer didn't take.
+  var onDidWake: (() -> Void)?
+
+  private var rootPort: io_connect_t = 0
+  private var notifierObject: io_object_t = 0
+  private var notifyPortRef: IONotificationPortRef?
+
+  func start() {
+    guard rootPort == 0 else { return }
+    let refCon = Unmanaged.passUnretained(self).toOpaque()
+    rootPort = IORegisterForSystemPower(refCon, &notifyPortRef, Self.callback, &notifierObject)
+    guard rootPort != 0, let notifyPortRef = notifyPortRef else {
+      print("SleepMonitor: IORegisterForSystemPower failed")
+      return
+    }
+    CFRunLoopAddSource(
+      CFRunLoopGetMain(),
+      IONotificationPortGetRunLoopSource(notifyPortRef).takeUnretainedValue(),
+      .commonModes)
+  }
+
+  deinit {
+    guard rootPort != 0 else { return }
+    if let notifyPortRef = notifyPortRef {
+      CFRunLoopRemoveSource(
+        CFRunLoopGetMain(),
+        IONotificationPortGetRunLoopSource(notifyPortRef).takeUnretainedValue(),
+        .commonModes)
+    }
+    IODeregisterForSystemPower(&notifierObject)
+    IOServiceClose(rootPort)
+    if let notifyPortRef = notifyPortRef {
+      IONotificationPortDestroy(notifyPortRef)
+    }
+  }
+
+  /// The C callback can't capture context, so `self` is recovered from the
+  /// `refCon` we registered with.
+  private static let callback: IOServiceInterestCallback = {
+    refCon, _, messageType, messageArgument in
+    guard let refCon = refCon else { return }
+    let monitor = Unmanaged<SleepMonitor>.fromOpaque(refCon).takeUnretainedValue()
+    monitor.handle(messageType: messageType, argument: messageArgument)
+  }
+
+  private func handle(messageType: UInt32, argument: UnsafeMutableRawPointer?) {
+    switch messageType {
+    case kIOMessageSystemWillSleep:
+      // Do our teardown, *then* allow the transition. Holding the ack until
+      // the handler returns is what keeps the release from racing the radio.
+      onWillSleep?()
+      IOAllowPowerChange(rootPort, Int(bitPattern: argument))
+    case kIOMessageCanSystemSleep:
+      // Idle-sleep query — never veto; we only care about the actual sleep.
+      IOAllowPowerChange(rootPort, Int(bitPattern: argument))
+    case kIOMessageSystemHasPoweredOn:
+      // Informational — no acknowledgement required.
+      onDidWake?()
+    default:
+      break
+    }
+  }
+}

--- a/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
+++ b/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
@@ -37,15 +37,35 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
     /// hosts) can legitimately take 30-45s, and a false-positive timeout
     /// is worse than waiting a beat longer.
     static let pairTimeout: TimeInterval = 60
+    /// How long after wake to wait before deciding whether the peer holds a
+    /// peripheral we released for sleep. Gives Wi-Fi time to reassociate so a
+    /// peer that's actively using the peripheral doesn't look unreachable and
+    /// get it yanked back.
+    static let wakeReclaimDelay: TimeInterval = 5
   }
 
   // MARK: - Dependencies
 
   private let bluetoothQueue = DispatchQueue(label: Constants.queueLabel, qos: .userInitiated)
 
+  /// Releases held peripherals just before this Mac sleeps. A sleeping Mac
+  /// can't be asked to release over the network, so we hand them off *before*
+  /// becoming unreachable.
+  private let sleepMonitor = SleepMonitor()
+
   // MARK: - Properties
 
+  /// `@AppStorage` key for the "release peripherals when this Mac sleeps"
+  /// preference. Referenced by the Other settings tab's toggle too, so it
+  /// lives here as the single source of truth for the key string.
+  static let releaseOnSleepDefaultsKey = "releaseHeldPeripheralsOnSleep"
+
   @AppStorage("peripherals") private var peripheralsData: Data = Data()
+
+  /// When set (default), `releaseHeldPeripheralsForSleep` runs on system
+  /// sleep. Off lets a user keep a peripheral bonded to a Mac that sleeps.
+  @AppStorage(BluetoothPeripheralStore.releaseOnSleepDefaultsKey)
+  private var releaseOnSleep: Bool = true
 
   @Published private(set) var peripherals: [BluetoothPeripheral] = [] {
     didSet {
@@ -72,6 +92,11 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
   /// timer flips the peripheral back to `.disconnected` so the UI unsticks.
   private var pairTimers: [String: DispatchSourceTimer] = [:]
 
+  /// MAC addresses released by `releaseHeldPeripheralsForSleep` on the last
+  /// sleep. On wake we reclaim any the peer didn't take. The process stays
+  /// alive across sleep, so an in-memory set is enough.
+  private var peripheralsReleasedForSleep: Set<String> = []
+
   /// Global IOBluetooth connect observer. Fires for *any* device the OS
   /// pairs/connects, including ones the user connects via the system
   /// Bluetooth menu (not via Magic Switch). Used to keep the Peripheral tab
@@ -97,6 +122,118 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
     loadPeripherals()
     fetchConnectedPeripherals()
     registerForSystemBluetoothConnects()
+    setupSleepRelease()
+  }
+
+  /// Hand held peripherals back to the peer the moment before this Mac
+  /// sleeps, so they're free for the peer to take rather than stranded on a
+  /// machine that can no longer be reached to release them.
+  private func setupSleepRelease() {
+    sleepMonitor.onWillSleep = { [weak self] in
+      self?.releaseHeldPeripheralsForSleep()
+    }
+    sleepMonitor.onDidWake = { [weak self] in
+      self?.reclaimPeripheralsAfterWake()
+    }
+    sleepMonitor.start()
+  }
+
+  /// Runs (on main) from `SleepMonitor` immediately before sleep, with the
+  /// power transition held until it returns. Releases every peripheral this
+  /// Mac currently holds so the peer can take it cleanly, and records them so
+  /// `reclaimPeripheralsAfterWake` can take back any the peer didn't.
+  ///
+  /// Gated on the peer looking present (paired + a registered device we're
+  /// currently seeing on Bonjour). If no peer is around there's no one to
+  /// hand off to, so we keep the peripherals bonded rather than orphan them —
+  /// `IORegisterForSystemPower` can't read a peer that isn't there.
+  ///
+  /// The IOBluetooth removes run synchronously on `bluetoothQueue` (the only
+  /// place IOBluetooth is touched) so they land before the radio powers down.
+  private func releaseHeldPeripheralsForSleep() {
+    peripheralsReleasedForSleep = []
+    guard releaseOnSleep,
+      PairingStore.shared.isPaired,
+      NetworkDeviceStore.shared.networkDevices.contains(where: { $0.isActive })
+    else { return }
+
+    // Snapshot `peripherals` on main before hopping to the Bluetooth queue.
+    let held = peripherals
+    guard !held.isEmpty else { return }
+
+    var releasedIDs: [String] = []
+    bluetoothQueue.sync {
+      for peripheral in held {
+        guard let device = IOBluetoothDevice(addressString: peripheral.id),
+          device.isConnected()
+        else { continue }
+        if device.responds(to: Selector(("remove"))) {
+          device.perform(Selector(("remove")))
+        } else {
+          _ = device.closeConnection()
+        }
+        releasedIDs.append(peripheral.id)
+      }
+    }
+
+    // Back on main (we never left it); reflect the releases in the UI so the
+    // Peripheral tab is correct on wake, and remember them for reclaim.
+    peripheralsReleasedForSleep = Set(releasedIDs)
+    for id in releasedIDs {
+      setConnectionState(.disconnected, for: id)
+    }
+    if !releasedIDs.isEmpty {
+      print("Released \(releasedIDs.count) peripheral(s) before sleep")
+    }
+  }
+
+  /// Runs (on main) from `SleepMonitor` after wake. For each peripheral we
+  /// released for sleep, ask the peer whether it actually took it; reclaim
+  /// only the ones it didn't (or can't be reached for). Waits
+  /// `Constants.wakeReclaimDelay` first so the network can reassociate —
+  /// otherwise a peer actively using the peripheral could look unreachable
+  /// and we'd wrongly grab it back.
+  private func reclaimPeripheralsAfterWake() {
+    let ids = peripheralsReleasedForSleep
+    peripheralsReleasedForSleep = []
+    guard !ids.isEmpty else { return }
+
+    DispatchQueue.main.asyncAfter(deadline: .now() + Constants.wakeReclaimDelay) {
+      [weak self] in
+      guard let self = self else { return }
+      // The registered peer (not gated on `isActive`: Bonjour may not have
+      // re-resolved yet, but `executeHoldsOne` actually connects, so
+      // reachability is decided there).
+      let device = NetworkDeviceStore.shared.networkDevices.first
+      for id in ids {
+        guard let peripheral = self.peripherals.first(where: { $0.id == id }) else { continue }
+        guard let device = device, PairingStore.shared.isPaired else {
+          // No peer to ask — these are ours; take them back.
+          self.connectPeripheral(peripheral)
+          continue
+        }
+        NetworkDeviceStore.shared.executeHoldsOne(address: id, on: device) {
+          [weak self] result in
+          guard let self = self else { return }
+          // `.success` = peer holds it (in use over there) → leave it.
+          // Any `.failure` (peer says no, or unreachable) → take it back.
+          if case .failure = result {
+            self.connectPeripheral(peripheral)
+          }
+        }
+      }
+    }
+  }
+
+  /// Whether this Mac currently has a live Bluetooth connection to the
+  /// peripheral with `address`. Answered off the live IOBluetooth state on
+  /// `bluetoothQueue`; the completion fires on that queue. Used by the peer's
+  /// `HOLDS_ONE` query so its wake-time reclaim skips peripherals we hold.
+  func isHoldingPeripheral(address: String, completion: @escaping (Bool) -> Void) {
+    bluetoothQueue.async {
+      let connected = IOBluetoothDevice(addressString: address)?.isConnected() ?? false
+      completion(connected)
+    }
   }
 
   /// Register for every Bluetooth connect the OS sees, so the Peripheral

--- a/Magic Switch/Model/Store/NetworkDeviceStore.swift
+++ b/Magic Switch/Model/Store/NetworkDeviceStore.swift
@@ -205,6 +205,12 @@ enum DeviceCommand: String, Codable {
   /// Two-frame: opcode then a single peripheral's MAC address. The peer
   /// connects just that peripheral.
   case connectOne = "CONNECT_ONE"
+  /// Two-frame: opcode then a single peripheral's MAC address. The peer acks
+  /// `OP_SUCCESS` if it currently holds (has a live Bluetooth connection to)
+  /// that peripheral, `OP_FAILED` otherwise. Read-only — used by the
+  /// wake-time reclaim to avoid grabbing a peripheral the peer is actively
+  /// using.
+  case holdsOne = "HOLDS_ONE"
   /// Single-frame no-op the peer immediately acks. Used as a secure-channel
   /// preflight: a TCP-open `checkHealth` doesn't prove the peer's app will
   /// accept commands, but a PING that handshakes + receives OP_SUCCESS
@@ -412,6 +418,18 @@ extension NetworkDeviceStore {
     completion: @escaping (Result<Void, OutgoingFailure>) -> Void
   ) {
     sendTwoFrameCommand(.connectOne, payload: address, to: device, completion: completion)
+  }
+
+  /// Asks `device` whether it currently holds the peripheral with the given
+  /// MAC. `.success` means the peer holds it (so leave it alone); any
+  /// `.failure` — an explicit "no" or an unreachable peer — means it's free
+  /// for us to reclaim. Two-frame protocol mirroring `executeUnregisterOne`.
+  func executeHoldsOne(
+    address: String,
+    on device: NetworkDevice,
+    completion: @escaping (Result<Void, OutgoingFailure>) -> Void
+  ) {
+    sendTwoFrameCommand(.holdsOne, payload: address, to: device, completion: completion)
   }
 
   /// Shared helper for "opcode + single payload frame, await OP_SUCCESS".

--- a/Magic Switch/View/Settings/OtherSettingsView.swift
+++ b/Magic Switch/View/Settings/OtherSettingsView.swift
@@ -8,6 +8,8 @@ struct OtherSettingsView: View {
   @Environment(\.openURL) private var openURL
   @ObservedObject private var updateChecker = UpdateChecker.shared
   @State private var launchAtLogin: Bool = false
+  @AppStorage(BluetoothPeripheralStore.releaseOnSleepDefaultsKey)
+  private var releaseOnSleep: Bool = true
 
   // MARK: - View Content
 
@@ -20,6 +22,12 @@ struct OtherSettingsView: View {
             .onChange(of: launchAtLogin, perform: setLaunchAtLogin)
             .help("Start Magic Switch automatically when you log in to this Mac.")
         }
+      }
+      Section {
+        Toggle("Release peripherals when this Mac sleeps", isOn: $releaseOnSleep)
+          .help(
+            "When this Mac sleeps, hand its Magic peripherals back so your other Mac can take them. A sleeping Mac can't be asked to release them over the network, so Magic Switch releases them just before sleeping. Turn off to keep a peripheral bonded to this Mac while it sleeps."
+          )
       }
       Section {
         SettingsRowView(


### PR DESCRIPTION
A Mac that sleeps while holding the Magic peripherals can't be asked to release them over the network, so the peer can't take them — the radio stays alive in lid-closed sleep and keeps the single-host bond. Release them just before sleeping instead, while we can still do it locally.

- SleepMonitor wraps IORegisterForSystemPower (not NSWorkspace.willSleepNotification, which can't delay the transition): onWillSleep holds sleep until the IOBluetooth release lands; onDidWake drives reclaim.
- Release is gated on the peer looking present (paired + a registered device active on Bonjour). If no peer is around we keep the peripherals bonded rather than orphan them.
- On wake, reclaim any released peripheral the peer didn't take: the new read-only HOLDS_ONE opcode asks the peer whether it holds the MAC; OP_SUCCESS = leave it (in use over there), any failure (no, or unreachable) = take it back. A settle delay lets Wi-Fi reassociate first so an actively-used peripheral isn't yanked back.
- New 'Release peripherals when this Mac sleeps' toggle (default on) in the Other settings tab.