### PR TITLE
ci: bump remaining node20 Actions to node24 (ci.yml, check-format.yml)

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
@@ -36,7 +36,7 @@ jobs:
 
       - name: Comment PR
         if: steps.format.outputs.format_has_issues == 'true'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 


### PR DESCRIPTION
PR #33 modernized release.yml but left the CI and format-check workflows on the deprecated Node 20 runtime. This finishes the job:

- actions/checkout v4 (node20) -> v6.0.3 (node24); same SHA already used in release.yml, so consistent with what's running there.
- actions/github-script v7 (node20) -> v9.0.0 (node24). Only usage is the issues.createComment PR-comment in check-format.yml; that API is stable across these majors.

Clears the 2026-06-16 Node 20 runner deprecation for these workflows. Still SHA-pinned with # vX.Y.Z comments.