### PR TITLE
ci: point pnpm action-setup at .github/release/package.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,12 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          # The pnpm tooling lives under .github/release/, not the repo root,
+          # so the action must read its pinned `packageManager` version from
+          # there. Without this it scans the (nonexistent) root package.json
+          # and fails with "No pnpm version is specified".
+          package_json_file: .github/release/package.json
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -155,6 +161,12 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          # The pnpm tooling lives under .github/release/, not the repo root,
+          # so the action must read its pinned `packageManager` version from
+          # there. Without this it scans the (nonexistent) root package.json
+          # and fails with "No pnpm version is specified".
+          package_json_file: .github/release/package.json
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## Problem

The Release workflow fails at the **Set up pnpm** step with `No pnpm version is specified.`

`pnpm/action-setup` reads the pnpm version from the `packageManager` key in `package.json`, defaulting to the **repo root**. This repo has no root `package.json` — the release tooling (and its `packageManager: "pnpm@10.6.4"` pin) lives under `.github/release/`. So the action had no version to install and bailed before Node setup, install, or version determination ran. Fallout from #35.

## Fix

Point both the `version` and `release` jobs' pnpm steps at `.github/release/package.json` via `package_json_file`. Keeps a single source of truth (the lockfile there already pins the version) rather than duplicating it inline.