### PR TITLE
fix: adopt already-connected peripheral instead of stranding at "(Pairing…)"

### DIFF
--- a/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
+++ b/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
@@ -582,6 +582,18 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
         return
       }
 
+      // Already connected — e.g. macOS reconnected this bonded peripheral on
+      // its own while the auto-reconnect watcher's HOLDS_ONE probe was in
+      // flight, so by the time we got here there's nothing left to pair.
+      // Starting an `IOBluetoothDevicePair` on an already-connected device
+      // never fires `devicePairingFinished`, stranding the UI at `.connecting`
+      // ("(Pairing…)"). Adopt the live connection instead.
+      if btDevice.isConnected() {
+        self.setConnectionState(.connected, for: peripheral.id)
+        self.registerForDisconnect(device: btDevice, address: peripheral.id)
+        return
+      }
+
       if btDevice.rssi() == Constants.invalidRSSI {
         print("\(peripheral.name) is out of range or not responding")
         self.setConnectionState(.disconnected, for: peripheral.id)


### PR DESCRIPTION
## Problem

The auto-reconnect watcher (#36) can leave a peripheral stuck showing **(Pairing…)** in the menu forever, even though it is actually connected and working.

The reclaim path (`reclaimIfPeerIsFree`) does a `HOLDS_ONE` **network round-trip to the peer** before deciding to re-pair. During that window macOS frequently reconnects the bonded device on its own. By the time `connectPeripheral` runs, the device is already connected — but `connectPeripheral` only checked Bluetooth power and RSSI, never `isConnected()`, so it still started an `IOBluetoothDevicePair`. Pairing an already-connected device never fires `devicePairingFinished`, so the state machine is stranded at `.connecting`.

## Fix

Short-circuit in `connectPeripheral`: if the device is already connected, adopt the live connection (set `.connected`, register the disconnect observer so a future genuine drop re-arms the watcher) instead of pairing. The watcher then disarms on its next tick.

Placing the check in `connectPeripheral` rather than just the watcher path also protects the interactive `takePeripheralFromPeer` / per-peripheral menu paths from the same stranding.

## Testing

- `xcodebuild ... CODE_SIGNING_ALLOWED=NO build` succeeds.
- `swift format` leaves the change untouched.