### PR TITLE
fix: reconnect a bonded peripheral instead of re-pairing it

### DIFF
--- a/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
+++ b/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
@@ -582,15 +582,29 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
         return
       }
 
-      // Already connected — e.g. macOS reconnected this bonded peripheral on
-      // its own while the auto-reconnect watcher's HOLDS_ONE probe was in
-      // flight, so by the time we got here there's nothing left to pair.
-      // Starting an `IOBluetoothDevicePair` on an already-connected device
-      // never fires `devicePairingFinished`, stranding the UI at `.connecting`
-      // ("(Pairing…)"). Adopt the live connection instead.
-      if btDevice.isConnected() {
-        self.setConnectionState(.connected, for: peripheral.id)
-        self.registerForDisconnect(device: btDevice, address: peripheral.id)
+      // Already bonded to this Mac. A peripheral we're holding that merely
+      // dropped — power cycle, briefly out of range, wake — keeps its link
+      // key, so macOS reconnects it on its own. Running
+      // `IOBluetoothDevicePair.start()` on a bonded device re-runs bonding and
+      // forces a disconnect/reconnect cycle that fights that reconnect (and
+      // strands the UI at "(Pairing…)" — the pair callback never fires for an
+      // already-connected device, and `fetchConnectedPeripherals` won't
+      // overwrite the in-flight `.connecting`). So adopt the live connection,
+      // or just open one — never re-pair. A peripheral handed to the peer was
+      // `-remove`d (see `unregisterFromPC`), so it isn't bonded here and falls
+      // through to the pairing path below: that's the take-from-peer case.
+      if btDevice.isConnected() || btDevice.isPaired() {
+        if !btDevice.isConnected() {
+          _ = btDevice.openConnection()
+        }
+        if btDevice.isConnected() {
+          self.setConnectionState(.connected, for: peripheral.id)
+          self.registerForDisconnect(device: btDevice, address: peripheral.id)
+        } else {
+          // Bonded but didn't come up (still booting / out of range). Leave it
+          // disconnected; macOS or the watcher's next probe will bring it back.
+          self.setConnectionState(.disconnected, for: peripheral.id)
+        }
         return
       }
 
@@ -979,8 +993,10 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
     }
   }
 
-  /// Checks live IOBluetooth reachability for `peripheral` off the main queue;
-  /// if it's back in range, hands off to `reclaimIfPeerIsFree`. Marks the id
+  /// Checks live IOBluetooth state for `peripheral` off the main queue. If it's
+  /// already connected, adopts it; if it's back in range and still bonded here,
+  /// reconnects locally (it's ours); otherwise hands off to
+  /// `reclaimIfPeerIsFree` to consult the peer before pairing. Marks the id
   /// in-flight so overlapping ticks skip it until this resolves.
   private func probeAndReclaim(_ peripheral: BluetoothPeripheral) {
     let id = peripheral.id
@@ -990,11 +1006,13 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
       // RSSI is the "is it back?" signal — `invalidRSSI` (127) means we can't
       // see it, the same gate `connectPeripheral` uses. Cheap while absent.
       var alreadyConnected = false
+      var bondedHere = false
       var reachable = false
       if IOBluetoothHostController.default().powerState != kBluetoothHCIPowerStateOFF,
         let device = IOBluetoothDevice(addressString: id)
       {
         alreadyConnected = device.isConnected()
+        bondedHere = device.isPaired()
         reachable = device.rssi() != Constants.invalidRSSI
       }
       DispatchQueue.main.async { [weak self] in
@@ -1024,6 +1042,16 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
         guard reachable else {
           // Still gone — wait for the next tick.
           self.reconnectInFlight.remove(id)
+          return
+        }
+        if bondedHere {
+          // Still bonded to this Mac, so it's ours: the peer can't hold a
+          // device whose link key lives here. Skip the HOLDS_ONE query and
+          // reconnect locally — `connectPeripheral` opens the connection
+          // without re-pairing (re-pairing a bonded device forces a
+          // disconnect/reconnect cycle and fights macOS's own reconnect).
+          self.reconnectInFlight.remove(id)
+          self.connectPeripheral(peripheral, announcePairTimeout: false)
           return
         }
         self.reclaimIfPeerIsFree(peripheral)


### PR DESCRIPTION
## Problem

A peripheral that drops while it is held on this Mac — power-cycling the keyboard, going briefly out of range, waking from sleep — stays **bonded** to this Mac (its link key is intact, since we never handed it off). macOS reconnects bonded devices on its own. But the auto-reconnect watcher (#36), catching the device *reachable but not yet connected*, ran `IOBluetoothDevicePair.start()` on it anyway.

Re-pairing an already-bonded device:
- re-runs the bonding handshake, **forcing a disconnect/reconnect cycle** (the keyboard visibly drops and reconnects), and
- strands the menu at **"(Pairing…)"** — the pair callback never fires for an already-connected device, and `fetchConnectedPeripherals` deliberately won'''t overwrite an in-flight `.connecting`, so macOS'''s own reconnect can'''t rescue the state.

## Fix

`isPaired()` cleanly separates the two reclaim semantics:

- **Handed to the peer** → `unregisterFromPC` used the private `-remove` selector to delete the bond, so the device is **not** bonded here → it must be paired (the take-from-peer path, unchanged).
- **Merely dropped** → still bonded here → it'''s ours → **open the connection rather than re-pair**.

Two layers:
1. `connectPeripheral` adopts a live connection (or `openConnection()`s a bonded-but-disconnected one) instead of pairing whenever the device is already bonded — protecting every caller (watcher, wake-reclaim, interactive).
2. The watcher'''s `probeAndReclaim` routes a bonded device straight to that gentle reconnect and **skips the `HOLDS_ONE` peer query** — the peer can'''t hold a device whose link key lives on this Mac.

## Testing

- `xcodebuild ... CODE_SIGNING_ALLOWED=NO build` succeeds; `swift format lint` clean.
- Manual: restart the keyboard while it'''s held on this Mac — it should settle to connected with no "(Pairing…)" hang and no double drop/reconnect.