### PR TITLE
fix: always check the peer (HOLDS_ONE) before reclaiming, even when bonded

### DIFF
--- a/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
+++ b/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
@@ -994,9 +994,10 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
   }
 
   /// Checks live IOBluetooth state for `peripheral` off the main queue. If it's
-  /// already connected, adopts it; if it's back in range and still bonded here,
-  /// reconnects locally (it's ours); otherwise hands off to
-  /// `reclaimIfPeerIsFree` to consult the peer before pairing. Marks the id
+  /// already connected, adopts it; if it's back in range, hands off to
+  /// `reclaimIfPeerIsFree`, which consults the peer (`HOLDS_ONE`) before
+  /// reclaiming — Magic devices stay bonded to *both* Macs, so being paired
+  /// here does not mean the peer isn't actively using it. Marks the id
   /// in-flight so overlapping ticks skip it until this resolves.
   private func probeAndReclaim(_ peripheral: BluetoothPeripheral) {
     let id = peripheral.id
@@ -1006,13 +1007,11 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
       // RSSI is the "is it back?" signal — `invalidRSSI` (127) means we can't
       // see it, the same gate `connectPeripheral` uses. Cheap while absent.
       var alreadyConnected = false
-      var bondedHere = false
       var reachable = false
       if IOBluetoothHostController.default().powerState != kBluetoothHCIPowerStateOFF,
         let device = IOBluetoothDevice(addressString: id)
       {
         alreadyConnected = device.isConnected()
-        bondedHere = device.isPaired()
         reachable = device.rssi() != Constants.invalidRSSI
       }
       DispatchQueue.main.async { [weak self] in
@@ -1042,16 +1041,6 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
         guard reachable else {
           // Still gone — wait for the next tick.
           self.reconnectInFlight.remove(id)
-          return
-        }
-        if bondedHere {
-          // Still bonded to this Mac, so it's ours: the peer can't hold a
-          // device whose link key lives here. Skip the HOLDS_ONE query and
-          // reconnect locally — `connectPeripheral` opens the connection
-          // without re-pairing (re-pairing a bonded device forces a
-          // disconnect/reconnect cycle and fights macOS's own reconnect).
-          self.reconnectInFlight.remove(id)
-          self.connectPeripheral(peripheral, announcePairTimeout: false)
           return
         }
         self.reclaimIfPeerIsFree(peripheral)


### PR DESCRIPTION
## Problem (regression from #40)

#40 let the auto-reconnect watcher **skip the `HOLDS_ONE` peer check** for a peripheral still bonded to this Mac, on the premise that *"the peer can'''t hold a device whose link key lives here."*

That premise is wrong. Apple'''s Magic devices remember multiple hosts and stay **bonded to both Macs** at once (the README'''s setup step pairs each peripheral to both, and they only *connect* to one at a time). So `isPaired()` being true here says nothing about which Mac is currently connected.

### The hole this opened

1. This Mac holds the keyboard, then sleeps (lid close) without releasing it (`releaseOnSleep` off, or no active peer at sleep time) — so it stays bonded.
2. During the downtime the user moves the keyboard to the **other** Mac via its Magic Switch. The other Mac can'''t reach a sleeping Mac to make it `-remove`, so it pairs locally — and this Mac'''s bond persists.
3. This Mac wakes, the watcher reclaims everything it was holding. With the skip, it reconnects the keyboard **without asking** → it yanks the keyboard back from the Mac that legitimately holds it.

Answering the actual question that surfaced this: *before reclaiming, does it check whether the peer claimed the peripheral?* — after #40 the answer was "no, not when bonded." It should always be "yes."

## Fix

Revert the bonded-device skip so every reclaim goes through `reclaimIfPeerIsFree` → `HOLDS_ONE` first. The gentle reconnect from #40 stays: `connectPeripheral` still opens the connection instead of re-pairing a bonded device (that is what fixed the original re-pair/disconnect loop), but it now only runs **after** the peer confirms it isn'''t holding the peripheral.

## Testing

- `xcodebuild ... CODE_SIGNING_ALLOWED=NO build` succeeds; `swift format lint` clean.
- Power-cycle reclaim still works (peer says not-holding → gentle reconnect, no re-pair loop).
- Contested case: peer holding the peripheral → `HOLDS_ONE` success → this Mac stands down instead of stealing it.