### PR TITLE
feat: flash the transfer arrow icon for per-peripheral switches

### DIFF
--- a/Magic Switch/AppDelegate/AppDelegate.swift
+++ b/Magic Switch/AppDelegate/AppDelegate.swift
@@ -33,9 +33,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   private var pingObserver: NSObjectProtocol?
   /// Resets the status-bar icon back to its real state after a Ping flash.
   private var pingFlashTimer: DispatchSourceTimer?
-  /// Observers for inbound peripheral-handoff posts from `IncomingConnection`.
+  /// Observers for inbound full-set peripheral-handoff posts from
+  /// `IncomingConnection`.
   private var transferReceiveObserver: NSObjectProtocol?
   private var transferReleaseObserver: NSObjectProtocol?
+  /// Same, for single-peripheral switches — posted both by the local
+  /// per-peripheral senders and by the incoming `.connectOne` /
+  /// `.unregisterOne` handlers.
+  private var transferIncomingOneObserver: NSObjectProtocol?
+  private var transferOutgoingOneObserver: NSObjectProtocol?
   /// Direction the status-bar icon should currently advertise. `idle` falls
   /// through to the normal/needs-attention logic in `refreshStatusBarIcon`.
   private enum TransferState {
@@ -136,6 +142,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       NotificationCenter.default.removeObserver(token)
     }
     if let token = transferReleaseObserver {
+      NotificationCenter.default.removeObserver(token)
+    }
+    if let token = transferIncomingOneObserver {
+      NotificationCenter.default.removeObserver(token)
+    }
+    if let token = transferOutgoingOneObserver {
       NotificationCenter.default.removeObserver(token)
     }
   }
@@ -297,6 +309,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
     transferReleaseObserver = NotificationCenter.default.addObserver(
       forName: .magicSwitchReceivedUnregisterAll, object: nil, queue: .main
+    ) { [weak self] _ in
+      self?.beginTransferAutoEnd(.sending)
+    }
+    transferIncomingOneObserver = NotificationCenter.default.addObserver(
+      forName: .magicSwitchPeripheralIncoming, object: nil, queue: .main
+    ) { [weak self] _ in
+      self?.beginTransferAutoEnd(.receiving)
+    }
+    transferOutgoingOneObserver = NotificationCenter.default.addObserver(
+      forName: .magicSwitchPeripheralOutgoing, object: nil, queue: .main
     ) { [weak self] _ in
       self?.beginTransferAutoEnd(.sending)
     }

--- a/Magic Switch/Manager/IncomingConnection.swift
+++ b/Magic Switch/Manager/IncomingConnection.swift
@@ -18,6 +18,16 @@ extension Notification.Name {
   /// status-bar icon to the "sending peripherals" state.
   static let magicSwitchReceivedUnregisterAll = Notification.Name(
     "magicSwitchReceivedUnregisterAll")
+  /// Per-peripheral counterparts of the `…ConnectAll` / `…UnregisterAll`
+  /// signals above: the same status-bar arrows, but for a single-device
+  /// switch. Posted both by this Mac's per-peripheral senders
+  /// (`takePeripheralFromPeer` / `sendPeripheralToPeer`) and by the incoming
+  /// `.connectOne` / `.unregisterOne` handlers, so both Macs show arrows
+  /// pointing the same physical way during a one-peripheral handoff.
+  static let magicSwitchPeripheralIncoming = Notification.Name(
+    "magicSwitchPeripheralIncoming")
+  static let magicSwitchPeripheralOutgoing = Notification.Name(
+    "magicSwitchPeripheralOutgoing")
 }
 
 /// Per-accept handler. Owns the NWConnection, its SecureChannel, idle/total
@@ -264,6 +274,8 @@ final class IncomingConnection {
       let store = bluetoothStore
       let address = message
       DispatchQueue.main.async {
+        // Peripheral is leaving this Mac for the peer — flash the sending arrow.
+        NotificationCenter.default.post(name: .magicSwitchPeripheralOutgoing, object: nil)
         if let peripheral = store.peripherals.first(where: { $0.id == address }) {
           store.unregisterFromPC(peripheral)
         }
@@ -281,6 +293,8 @@ final class IncomingConnection {
       let store = bluetoothStore
       let address = message
       DispatchQueue.main.async {
+        // Peripheral is arriving at this Mac — flash the receiving arrow.
+        NotificationCenter.default.post(name: .magicSwitchPeripheralIncoming, object: nil)
         if let peripheral = store.peripherals.first(where: { $0.id == address }) {
           store.connectPeripheral(peripheral)
         }

--- a/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
+++ b/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
@@ -454,6 +454,9 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
       return
     }
 
+    // Peripheral is arriving at this Mac — flash the receiving arrow, the same
+    // signal the full-set take raises on the menu-bar icon.
+    NotificationCenter.default.post(name: .magicSwitchPeripheralIncoming, object: nil)
     setConnectionState(.connecting, for: peripheral.id)
     schedulePairWatchdog(for: peripheral, announceTimeout: true)
     networkStore.executeUnregisterOne(address: peripheral.id, on: device) {
@@ -501,6 +504,8 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
       unregisterFromPC(peripheral)
       return
     }
+    // Peripheral is leaving this Mac for the peer — flash the sending arrow.
+    NotificationCenter.default.post(name: .magicSwitchPeripheralOutgoing, object: nil)
     unregisterFromPC(peripheral)
     waitForLocalDisconnect(of: peripheral) { success in
       guard success else {


### PR DESCRIPTION
## Problem

The menu-bar transfer arrows (`arrow.up.right.circle.fill` "sending" / `arrow.down.left.circle.fill` "receiving") only appear during a **full-set** switch — clicking a Mac row, which runs `CONNECT_ALL` / `UNREGISTER_ALL`. A **per-peripheral** switch — clicking a single peripheral row in the menu, or the Peripheral tab's per-device buttons — changed only that peripheral's row (`(Pairing…)` / checkmark) and left the status-bar icon idle on both Macs. It should reflect a single-peripheral handoff too.

## Change

Add two direction-based signals, `magicSwitchPeripheralIncoming` / `magicSwitchPeripheralOutgoing`, posted by:

- the **local** per-peripheral senders — `takePeripheralFromPeer` -> incoming, `sendPeripheralToPeer` -> outgoing (posted *after* the no-peer guard, so a local-only fallback with no reachable peer doesn't flash a cross-gap arrow); and
- the **incoming** `.connectOne` (-> incoming) / `.unregisterOne` (-> outgoing) handlers.

`AppDelegate` observes both and drives the existing `.receiving` / `.sending` icon via `beginTransferAutoEnd`, so **both Macs show arrows pointing the same physical way** during a one-peripheral handoff — exactly like the full-set switch. Posting at the store layer covers both entry points (menu rows and the Peripheral tab).

Both sides use the receiver's 5s auto-end (the all-set sender tracks exact completion because it orchestrates rollback; a per-peripheral switch is fire-and-forget, and the per-row `(Pairing…)` state still carries exact progress, so a fixed flash is the right fit).

## Testing

- `xcodebuild -project "Magic Switch.xcodeproj" -scheme "Magic Switch" -configuration Debug build CODE_SIGNING_ALLOWED=NO` -> **BUILD SUCCEEDED**.
- `swift format lint` -> no new warnings (only the pre-existing `.forEach` style nits already on `main`).