### PR TITLE
fix: keep auto-reconnect probes off the switch rate limiter and untrusted peers

### DIFF
--- a/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
+++ b/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
@@ -337,9 +337,11 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
         self.intentionalReleases.removeValue(forKey: id)
         guard let peripheral = self.peripherals.first(where: { $0.id == id }) else { continue }
         guard let device = NetworkDeviceStore.shared.networkDevices.first,
+          device.pendingFingerprint == nil,
           PairingStore.shared.isPaired
         else {
-          // No peer to ask — these are ours; take them back.
+          // No trusted peer to ask — none registered, or one flagged as a
+          // TOFU identity mismatch. Either way, reclaim locally.
           self.connectPeripheral(peripheral)
           continue
         }
@@ -1221,9 +1223,12 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
   private func reclaimIfPeerIsFree(_ peripheral: BluetoothPeripheral) {
     let id = peripheral.id
     guard PairingStore.shared.isPaired,
-      let device = NetworkDeviceStore.shared.networkDevices.first
+      let device = NetworkDeviceStore.shared.networkDevices.first,
+      device.pendingFingerprint == nil
     else {
-      // No peer to consult — it's ours; take it.
+      // No trusted peer to consult — none registered, or one flagged as a
+      // TOFU identity mismatch. Either way it's ours; reclaim locally rather
+      // than auto-probing an untrusted peer with our now-stale key.
       reconnectInFlight.remove(id)
       connectPeripheral(peripheral, announcePairTimeout: false)
       return

--- a/Magic Switch/Model/Store/NetworkDeviceStore.swift
+++ b/Magic Switch/Model/Store/NetworkDeviceStore.swift
@@ -513,7 +513,12 @@ extension NetworkDeviceStore {
     on device: NetworkDevice,
     completion: @escaping (Result<Void, OutgoingFailure>) -> Void
   ) {
-    sendTwoFrameCommand(.holdsOne, payload: address, to: device, completion: completion)
+    // `HOLDS_ONE` is only ever a background watcher/reclaim probe, never a user
+    // action — opt out of the outbound limiter so its fixed cadence can't trip
+    // the limiter that gates real switches (mirrors the reachability poll).
+    sendTwoFrameCommand(
+      .holdsOne, payload: address, to: device, countsTowardRateLimit: false,
+      completion: completion)
   }
 
   /// Shared helper for "opcode + single payload frame, await OP_SUCCESS".
@@ -524,13 +529,16 @@ extension NetworkDeviceStore {
     _ command: DeviceCommand,
     payload: String,
     to device: NetworkDevice,
+    countsTowardRateLimit: Bool = true,
     completion: @escaping (Result<Void, OutgoingFailure>) -> Void
   ) {
     guard PairingStore.shared.isPaired else {
       completion(.failure(.notPaired))
       return
     }
-    let outgoing = OutgoingConnection(host: device.host, port: UInt16(device.port))
+    let outgoing = OutgoingConnection(
+      host: device.host, port: UInt16(device.port),
+      countsTowardRateLimit: countsTowardRateLimit)
     outgoing.run(
       body: { channel, done in
         channel.send(Data(command.rawValue.utf8)) { err in


### PR DESCRIPTION
Follow-up extending the same outbound-rate-limiter decoupling from #44 to the auto-reconnect watcher's read-only `HOLDS_ONE` probes (fired every ~5s while recovering a dropped peripheral, so the watcher never yanks a peripheral the peer is actively using).

### Don't let background probes trip the switch rate limiter
`HOLDS_ONE` fed the shared `OutboundRateLimiter`, so a run of failing probes — a down peer, or several peripherals recovering at once — could trip it and fail-fast a *user-initiated* switch's preflight `.ping` (the row greys / the switch is rejected). Threads `countsTowardRateLimit: false` through `executeHoldsOne` so these fixed-cadence probes opt out, exactly as the reachability poll already does. Safe: the watcher's own bounds (in-flight guard, 5s timer, 600s give-up, post-failure local reconnect) already throttle it, and the outbound limiter is client-side back-off, not the security boundary.

### Don't probe TOFU-mismatched peers
Both probe sites (`reclaimIfPeerIsFree` and the wake-time reclaim) consulted `networkDevices.first` unconditionally, so a peer flagged as an identity mismatch (`pendingFingerprint` set) still got probed with our stale key — auth-failing into the *peer's* inbound rate limiter and reaching out to an identity TOFU exists to quarantine. Gates both on `pendingFingerprint == nil`, folding the mismatch into the existing "no trusted peer → reclaim locally" branch (the safe default for an untrusted peer).

Foreground switches were already guarded at the UI layer (`isSwitchable` checks `pendingFingerprint`) and the reachability poll already guards both ways — this just makes the background watcher consistent with them.

---
Builds on the `countsTowardRateLimit` plumbing from #44 (now on `main`); rebased onto `main` so the diff is just these two watcher fixes.
