### PR TITLE
fix: disable peripheral Release when no peer Mac is active

### DIFF
--- a/Magic Switch/View/Settings/BluetoothPeripheralSettingsView.swift
+++ b/Magic Switch/View/Settings/BluetoothPeripheralSettingsView.swift
@@ -185,6 +185,7 @@ private struct PeripheralRowView: View {
   var secondaryAction: (() -> Void)?
 
   @ObservedObject private var store = BluetoothPeripheralStore.shared
+  @ObservedObject private var networkStore = NetworkDeviceStore.shared
 
   private var connectionState: PeripheralConnectionState {
     store.connectionState(for: peripheral.id)
@@ -192,6 +193,14 @@ private struct PeripheralRowView: View {
 
   private var resolvedType: PeripheralType {
     store.peripheralType(for: peripheral)
+  }
+
+  /// Whether a paired peer Mac is currently reachable to take a released
+  /// peripheral. Releasing with no active peer just disconnects the peripheral
+  /// from both Macs, so the Release button is disabled until a peer is present.
+  /// Matches the handoff gate used elsewhere (e.g. `prepareForSleep`).
+  private var hasActivePeer: Bool {
+    networkStore.networkDevices.contains { $0.isActive }
   }
 
   var body: some View {
@@ -262,8 +271,11 @@ private struct PeripheralRowView: View {
     switch connectionState {
     case .connected:
       Button("Release", action: primaryAction)
+        .disabled(!hasActivePeer)
         .help(
-          "Release this peripheral from this Mac. If a peer Mac is paired, it'll take ownership automatically."
+          hasActivePeer
+            ? "Release this peripheral from this Mac. The peer Mac will take ownership automatically."
+            : "No peer Mac is currently available to take this peripheral. Releasing is disabled so it isn't left disconnected from both Macs."
         )
     case .connecting:
       Button("Pairing…", action: {})


### PR DESCRIPTION
## What

In **Settings → Peripherals**, the **Release** button on a registered peripheral is now disabled when no peer Mac is currently active.

## Why

Releasing a peripheral with no reachable peer fell back to a local-only unregister, leaving the peripheral disconnected from *both* Macs. Disabling Release until a peer is available avoids stranding it.

## Details

- `PeripheralRowView` now observes `NetworkDeviceStore.shared` and computes `hasActivePeer` via `networkDevices.contains { $0.isActive }` — the same handoff-availability gate used by `prepareForSleep`. Since `networkDevices` is `@Published`, the button enables/disables live as the peer comes and goes.
- The `.connected` case applies `.disabled(!hasActivePeer)` and a context-sensitive `.help` tooltip:
  - **Enabled:** "Release this peripheral from this Mac. The peer Mac will take ownership automatically." (dropped the now-redundant "If a peer Mac is paired…" conditional).
  - **Disabled:** "No peer Mac is currently available to take this peripheral. Releasing is disabled so it isn't left disconnected from both Macs."

Matches the existing disabled-button-with-tooltip pattern used by the `.connecting` ("Pairing…") case in the same view. Scoped to the Settings tab only — the menu-bar dropdown is unchanged.
