### PR TITLE
fix: disable Ping/Sync/Release while in flight and keep progress across tab switches

### DIFF
--- a/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
+++ b/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
@@ -603,12 +603,20 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
       unregisterFromPC(peripheral)
       return
     }
+    // Show "Releasing…" right away so the row greys out and stops accepting
+    // clicks while the preflight below runs — it can take up to 5s, and until
+    // it returns the button would otherwise still read "Release". On preflight
+    // failure we revert to `.connected`; on success `performSendHandoff`
+    // re-asserts `.releasing` after its `unregisterFromPC` (which lands
+    // `.disconnected`) in the same run-loop tick, so there's no flicker.
+    setConnectionState(.releasing, for: peripheral.id)
     networkStore.executeCommand(.ping, on: device) { [weak self] preflight in
       DispatchQueue.main.async {
         guard let self = self else { return }
         switch preflight {
         case .failure(let err):
           // Peer unreachable — nothing released, peripheral stays on this Mac.
+          self.setConnectionState(.connected, for: peripheral.id)
           self.setPeripheralError("Other Mac unreachable.", for: peripheral.id)
           NotificationManager.showNotification(
             title: "Switch Cancelled",

--- a/Magic Switch/Model/Store/NetworkDeviceStore.swift
+++ b/Magic Switch/Model/Store/NetworkDeviceStore.swift
@@ -19,6 +19,15 @@ protocol NetworkDeviceManageable {
   func updateNetworkDevice(_ device: NetworkDevice)
 }
 
+/// A user-initiated Device-tab operation currently in flight to a peer.
+/// Tracked in `NetworkDeviceStore` (not the view) so the row can disable its
+/// buttons and keep rendering progress across Settings tab switches — the
+/// view's local `@State` is reset when the tab is left and re-entered.
+enum DeviceOperation {
+  case ping
+  case sync(count: Int)
+}
+
 /// Manages the state and operations of network devices
 final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
   // MARK: - Singleton
@@ -44,6 +53,12 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
   @Published private(set) var deviceReachability: [String: Bool] = [:]
   private var reachabilityTimer: DispatchSourceTimer?
   private static let reachabilityInterval: TimeInterval = 30
+
+  /// In-flight Ping/Sync per device id. Set when the user taps Ping/Sync on the
+  /// Device tab and cleared when the op finishes; the view both disables the
+  /// buttons and renders the "Pinging…/Syncing…" line off this, so they survive
+  /// leaving and re-entering the tab (the view's own `@State` wouldn't).
+  @Published private(set) var inFlightOperations: [String: DeviceOperation] = [:]
 
   // MARK: - Computed Properties
 
@@ -242,14 +257,30 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
       return
     }
 
+    beginOperation(.ping, for: device.id)
     let senderName = Host.current().localizedName ?? "another Mac"
     // Put the sender's name in the title so the receiver's Notification
     // Center entry is informative at a glance.
     let title = "Notification from \(senderName)"
     let body = "Sent via Magic Switch."
-    sendNotificationOverSecure(to: device, title: title, message: body) { result in
-      completion?(result)
+    sendNotificationOverSecure(to: device, title: title, message: body) { [weak self] result in
+      DispatchQueue.main.async {
+        self?.endOperation(for: device.id)
+        completion?(result)
+      }
     }
+  }
+
+  // MARK: - In-Flight Operation Tracking
+
+  /// Marks a Device-tab operation as running for `deviceID`. Main-thread only.
+  private func beginOperation(_ op: DeviceOperation, for deviceID: String) {
+    inFlightOperations[deviceID] = op
+  }
+
+  /// Clears the in-flight marker for `deviceID`. Main-thread only.
+  private func endOperation(for deviceID: String) {
+    inFlightOperations.removeValue(forKey: deviceID)
   }
 
   // MARK: - Private Methods
@@ -445,6 +476,7 @@ extension NetworkDeviceStore {
       return
     }
 
+    beginOperation(.sync(count: peripherals.count), for: device.id)
     let outgoing = OutgoingConnection(host: device.host, port: UInt16(device.port))
     outgoing.run(
       body: { channel, done in
@@ -476,8 +508,11 @@ extension NetworkDeviceStore {
           }
         }
       },
-      completion: { result in
-        completion?(result)
+      completion: { [weak self] result in
+        DispatchQueue.main.async {
+          self?.endOperation(for: device.id)
+          completion?(result)
+        }
       }
     )
   }

--- a/Magic Switch/View/Settings/BluetoothPeripheralSettingsView.swift
+++ b/Magic Switch/View/Settings/BluetoothPeripheralSettingsView.swift
@@ -203,6 +203,11 @@ private struct PeripheralRowView: View {
     networkStore.networkDevices.contains { $0.isActive }
   }
 
+  /// The peer this Mac hands peripherals to, for the "Releasing to …" line.
+  private var peerName: String? {
+    networkStore.networkDevices.first?.name
+  }
+
   var body: some View {
     VStack(alignment: .leading, spacing: 4) {
       HStack {
@@ -225,6 +230,14 @@ private struct PeripheralRowView: View {
           .help("Add this peripheral to Magic Switch's list.")
           .accessibilityLabel("Add \(peripheral.name) to list")
         }
+      }
+
+      // Name the destination Mac while a handoff is in flight — the button
+      // only shows "Releasing…", which doesn't say where it's going.
+      if connectionState == .releasing {
+        Text(peerName.map { "Releasing to \($0)…" } ?? "Releasing…")
+          .font(.caption)
+          .foregroundColor(.secondary)
       }
 
       // Mirrors the dropdown's inline failure line. The store auto-fades the

--- a/Magic Switch/View/Settings/NetworkDeviceManagementView.swift
+++ b/Magic Switch/View/Settings/NetworkDeviceManagementView.swift
@@ -94,11 +94,13 @@ struct NetworkDeviceManagementView: View {
         onDeviceRegister: handleDeviceRegistration
       )
     }
-    // Clear stale Ping/Sync results whenever the user comes back to this
+    // Clear stale Ping/Sync *results* whenever the user comes back to this
     // tab (or first opens it). Keeps "<device> responded." / failure lines
     // from sticking around across Settings sessions when they're no longer
     // meaningful. Within a single tab visit, repeated actions still
-    // overwrite each other (existing behaviour, unchanged).
+    // overwrite each other (existing behaviour, unchanged). An in-progress
+    // Ping/Sync is unaffected — that lives in `networkStore.inFlightOperations`,
+    // not here, which is what lets its progress line survive a tab switch.
     .onAppear { operationResults.removeAll() }
     .alert(item: $activeAlert) { alert in
       switch alert {
@@ -154,7 +156,9 @@ struct NetworkDeviceManagementView: View {
   // MARK: - Private Methods
 
   private func handleDeviceNotification(_ device: NetworkDevice) {
-    operationResults[device.id] = OperationResult(success: true, message: "Pinging \(device.name)…")
+    // The "Pinging…" progress line is driven by `networkStore.inFlightOperations`
+    // (see `NetworkDeviceListView`) so it survives a tab switch; here we only
+    // record the terminal result.
     networkStore.sendNotification(to: device) { result in
       switch result {
       case .success:
@@ -184,10 +188,8 @@ struct NetworkDeviceManagementView: View {
     let peripherals = bluetoothStore.peripherals
     let count = peripherals.count
     let noun = count == 1 ? "peripheral" : "peripherals"
-    operationResults[device.id] = OperationResult(
-      success: true,
-      message: "Syncing \(count) \(noun) to \(device.name)…"
-    )
+    // "Syncing…" progress comes from `networkStore.inFlightOperations`; record
+    // only the terminal result here.
     networkStore.sendPeripheralSync(peripherals: peripherals, to: device) { result in
       switch result {
       case .success:
@@ -299,6 +301,7 @@ private struct NetworkDeviceListView: View {
   let onTrustPending: ((NetworkDevice) -> Void)?
 
   @ObservedObject private var pairing = PairingStore.shared
+  @ObservedObject private var networkStore = NetworkDeviceStore.shared
 
   init(
     devices: [NetworkDevice],
@@ -332,6 +335,9 @@ private struct NetworkDeviceListView: View {
     // top-aligns the row contents instead of centering them in the pill.
     // Letting the Form own the row layout keeps content vertically centered.
     ForEach(devices) { device in
+      // A Ping/Sync in flight disables both buttons (they share one secure
+      // channel and one status line) and drives the progress line below.
+      let inFlight = networkStore.inFlightOperations[device.id]
       VStack(alignment: .leading, spacing: 6) {
         HStack {
           Text(device.name)
@@ -339,7 +345,7 @@ private struct NetworkDeviceListView: View {
           Button(action: { action(device) }) {
             Text(buttonTitle)
           }
-          .disabled(!device.isActive || blockedByPairing)
+          .disabled(!device.isActive || blockedByPairing || inFlight != nil)
           .help(blockedByPairing ? NetworkDeviceManagementView.Help.needsPairing : actionHelp)
 
           if let onSync = onSyncPeripherals {
@@ -347,7 +353,7 @@ private struct NetworkDeviceListView: View {
               Image(systemName: "square.and.arrow.up")
                 .foregroundColor(.blue)
             }
-            .disabled(!device.isActive || blockedByPairing)
+            .disabled(!device.isActive || blockedByPairing || inFlight != nil)
             .help(
               blockedByPairing
                 ? NetworkDeviceManagementView.Help.needsPairing
@@ -384,12 +390,26 @@ private struct NetworkDeviceListView: View {
           .padding(.vertical, 2)
         }
 
-        if let result = operationResults[device.id] {
+        if let inFlight = inFlight {
+          Text(progressMessage(for: inFlight, device: device))
+            .font(.caption)
+            .foregroundColor(.secondary)
+        } else if let result = operationResults[device.id] {
           Text(result.message)
             .font(.caption)
             .foregroundColor(result.success ? .secondary : .red)
         }
       }
+    }
+  }
+
+  private func progressMessage(for op: DeviceOperation, device: NetworkDevice) -> String {
+    switch op {
+    case .ping:
+      return "Pinging \(device.name)…"
+    case .sync(let count):
+      let noun = count == 1 ? "peripheral" : "peripherals"
+      return "Syncing \(count) \(noun) to \(device.name)…"
     }
   }
 }


### PR DESCRIPTION
Two related UX fixes for buttons that fire async operations.

### Device tab (Ping / Sync)
- Both buttons now disable while **either** a Ping or Sync is in flight, instead of staying clickable.
- The "Pinging…" / "Syncing…" progress line now survives leaving and re-entering the Settings tab. It previously lived in the view's `@State`, which `.onAppear` reset; it now lives in `NetworkDeviceStore.inFlightOperations`, and the singleton store outlives tab switches.

### Peripheral tab (Release)
- Clicking **Release** now flips the row to `.releasing` immediately — **before** the up-to-5s ping preflight — so the button greys out at once instead of staying an enabled "Release" during that window. It reverts to `.connected` if the preflight fails (nothing was released yet).
- Added a "Releasing to `<peer Mac>`…" line under the peripheral, since the button label alone doesn't say where it's going.

### Notes
- Disabling both Device-tab buttons during either op is deliberate — they share one secure channel and one status line.
- Verified the periodic 2s fetch and the disconnect handler both skip `.releasing`, so the early state isn't clobbered while the peripheral is still physically connected.
- Builds clean with `CODE_SIGNING_ALLOWED=NO`; `swift format` applied.