### PR TITLE
feat: expose switching via a magicswitch:// URL scheme

### DIFF
--- a/Magic Switch.xcodeproj/project.pbxproj
+++ b/Magic Switch.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		0A00002000000000000000B6 /* UpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00002000000000000000A6 /* UpdateChecker.swift */; };
 		0A00001000000000000000B6 /* PairingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00001000000000000000A6 /* PairingSettingsView.swift */; };
 		076AB2202CE9D690004D45F0 /* BluetoothPeripheral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076AB2002CE9D690004D45F0 /* BluetoothPeripheral.swift */; };
+		0A00005000000000000000B9 /* SwitchURLCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00005000000000000000A9 /* SwitchURLCommand.swift */; };
 		076AB2212CE9D690004D45F0 /* NetworkDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076AB2012CE9D690004D45F0 /* NetworkDevice.swift */; };
 		076AB2222CE9D690004D45F0 /* BluetoothPeripheralStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076AB2032CE9D690004D45F0 /* BluetoothPeripheralStore.swift */; };
 		076AB2232CE9D690004D45F0 /* NetworkDeviceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076AB2042CE9D690004D45F0 /* NetworkDeviceStore.swift */; };
@@ -56,6 +57,7 @@
 		0A00002000000000000000A6 /* UpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateChecker.swift; sourceTree = "<group>"; };
 		0A00001000000000000000A6 /* PairingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingSettingsView.swift; sourceTree = "<group>"; };
 		076AB2002CE9D690004D45F0 /* BluetoothPeripheral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothPeripheral.swift; sourceTree = "<group>"; };
+		0A00005000000000000000A9 /* SwitchURLCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchURLCommand.swift; sourceTree = "<group>"; };
 		076AB2012CE9D690004D45F0 /* NetworkDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDevice.swift; sourceTree = "<group>"; };
 		076AB2032CE9D690004D45F0 /* BluetoothPeripheralStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothPeripheralStore.swift; sourceTree = "<group>"; };
 		076AB2042CE9D690004D45F0 /* NetworkDeviceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDeviceStore.swift; sourceTree = "<group>"; };
@@ -124,6 +126,7 @@
 			children = (
 				076AB2002CE9D690004D45F0 /* BluetoothPeripheral.swift */,
 				076AB2012CE9D690004D45F0 /* NetworkDevice.swift */,
+				0A00005000000000000000A9 /* SwitchURLCommand.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -308,6 +311,7 @@
 				0A00002000000000000000B6 /* UpdateChecker.swift in Sources */,
 				0A00001000000000000000B6 /* PairingSettingsView.swift in Sources */,
 				076AB2202CE9D690004D45F0 /* BluetoothPeripheral.swift in Sources */,
+				0A00005000000000000000B9 /* SwitchURLCommand.swift in Sources */,
 				076AB2212CE9D690004D45F0 /* NetworkDevice.swift in Sources */,
 				076AB2222CE9D690004D45F0 /* BluetoothPeripheralStore.swift in Sources */,
 				076AB2232CE9D690004D45F0 /* NetworkDeviceStore.swift in Sources */,

--- a/Magic Switch/AppDelegate/AppDelegate.swift
+++ b/Magic Switch/AppDelegate/AppDelegate.swift
@@ -376,12 +376,72 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
   }
 
+  // MARK: - URL Commands
+
+  /// External-control entry point: `magicswitch://switch` URLs, parsed by
+  /// `SwitchURLCommand`. macOS delivers them here whether the app was already
+  /// running or was just launched by the open.
+  func application(_ application: NSApplication, open urls: [URL]) {
+    for url in urls {
+      handleCommandURL(url)
+    }
+  }
+
+  private func handleCommandURL(_ url: URL) {
+    let command: SwitchURLCommand
+    switch SwitchURLCommand.parse(url) {
+    case .success(let parsed):
+      command = parsed
+    case .failure(let error):
+      // The caller is a script or hotkey with no UI of its own, so a
+      // notification is the only feedback channel — same for resolution
+      // failures below.
+      NotificationManager.showNotification(
+        title: "Invalid Switch Command", body: error.message, identifier: "url-command-invalid")
+      return
+    }
+    guard !command.selectors.isEmpty else {
+      performFullSetCommand(command.direction)
+      return
+    }
+    switch command.resolvePeripherals(in: bluetoothStore) {
+    case .success(let peripherals):
+      peripherals.forEach { bluetoothStore.switchPeripheral($0, direction: command.direction) }
+    case .failure(let error):
+      NotificationManager.showNotification(
+        title: "Invalid Switch Command", body: error.message, identifier: "url-command-invalid")
+    }
+  }
+
+  /// A command with no `peripheral=` filter. `take` uses the same engine as
+  /// the display trigger because it has to work while the peer is asleep (an
+  /// unreachable peer isn't holding the peripherals anymore); `send` and
+  /// `toggle` need the peer awake anyway, so they go through the menu's
+  /// health-checked path.
+  private func performFullSetCommand(_ direction: SwitchDirection) {
+    switch direction {
+    case .take:
+      takeAllPeripheralsIfAway()
+    case .send, .toggle:
+      guard let device = networkStore.networkDevices.first else {
+        NotificationManager.showNotification(
+          title: "Can't Switch",
+          body: "No Mac is registered — pick one in Settings → Device.",
+          identifier: "url-command-no-device")
+        return
+      }
+      performSwitch(with: device, direction: direction)
+    }
+  }
+
   // MARK: - Action Handlers
 
   /// Runs the switch handoff with `device`. Triggered by clicking a Mac row in
-  /// the menu. `checkHealth` confirms the peer's TCP port is open before we
-  /// touch any local Bluetooth state.
-  private func performSwitch(with device: NetworkDevice) {
+  /// the menu (`toggle`) and by the URL scheme's full-set `send` and `toggle`
+  /// (full-set `take` goes through `takeAllPeripheralsIfAway` instead — see
+  /// `performFullSetCommand`). `checkHealth` confirms the peer's TCP port is
+  /// open before we touch any local Bluetooth state.
+  private func performSwitch(with device: NetworkDevice, direction: SwitchDirection = .toggle) {
     // Don't start a full-set switch while a per-peripheral pair/handoff is in
     // flight: it would issue a re-entrant connect/unregister on a peripheral
     // that's already transitioning. The dropdown disables the Mac row for this
@@ -396,7 +456,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         switch result {
         case .success:
           self.bluetoothStore.checkActualConnectionStatusAsync { [weak self] status in
-            self?.handleSwitchAction(status: status, device: device)
+            self?.handleSwitchAction(status: status, device: device, direction: direction)
           }
         case .failure(let error):
           NotificationManager.showNotification(
@@ -415,7 +475,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
   private func handleSwitchAction(
     status: BluetoothPeripheralStore.ConnectionStatus,
-    device: NetworkDevice
+    device: NetworkDevice,
+    direction: SwitchDirection
   ) {
     switch status {
     case .allConnected:
@@ -443,6 +504,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         }
       }
     case .allDisconnected:
+      // An explicit `send` is idempotent: nothing on this Mac means nothing
+      // to do — a repeated hotkey must not turn into a take.
+      guard direction != .send else { return }
       takeAllPeripherals(from: device)
     case .partial:
       NotificationManager.showNotification(
@@ -516,15 +580,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     displayMonitor.start()
   }
 
-  /// A trigger display just connected (runs on main). Take the full set with
-  /// the same guards as the menu switch, plus two of its own: Bluetooth must
-  /// be healthy — an automatic trigger must never ask the peer to release
-  /// peripherals this Mac then can't take — and "everything already here" is
-  /// a silent no-op, so re-docking the Mac that owns the peripherals doesn't
-  /// spam. Unlike the menu there's no clicked row to target: use the trusted
-  /// peer, or fall back to a plain local grab when none is registered — the
-  /// display is a claim on the peripherals either way.
+  /// A trigger display just connected (runs on main). Announce it, then take
+  /// the full set through the shared external-claim engine below.
   private func handleTriggerDisplaysConnected(_ names: [String]) {
+    takeAllPeripheralsIfAway {
+      NotificationManager.showNotification(
+        title: "Display Connected",
+        body:
+          "\(names.joined(separator: ", ")) connected — switching your peripherals to this Mac.",
+        identifier: "display-trigger-switch"
+      )
+    }
+  }
+
+  /// Take the full set onto this Mac in response to an automatic or external
+  /// claim — the display trigger, the URL scheme's full-set `take` — with the
+  /// same guards as the menu switch, plus two of its own: Bluetooth must be
+  /// healthy — such a trigger must never ask the peer to release peripherals
+  /// this Mac then can't take — and "everything already here" is a silent
+  /// no-op, so a repeated trigger doesn't spam. Unlike the menu there's no
+  /// clicked row to target: use the trusted peer, or fall back to a plain
+  /// local grab when none is registered — the trigger is a claim on the
+  /// peripherals either way. `onTake` fires once a take is actually going to
+  /// happen, so the display trigger can announce itself.
+  private func takeAllPeripheralsIfAway(onTake: @escaping () -> Void = {}) {
     guard !bluetoothStore.peripherals.isEmpty,
       !bluetoothStore.isAnyPeripheralTransitioning,
       // The same states the status-bar icon treats as healthy (`.unknown`
@@ -533,12 +612,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     else { return }
     bluetoothStore.checkActualConnectionStatusAsync { [weak self] status in
       guard let self = self, status != .allConnected else { return }
-      NotificationManager.showNotification(
-        title: "Display Connected",
-        body:
-          "\(names.joined(separator: ", ")) connected — switching your peripherals to this Mac.",
-        identifier: "display-trigger-switch"
-      )
+      onTake()
       // Same trusted-peer rule as the sleep handoff: registered and not
       // parked behind an identity mismatch. Reachability isn't pre-checked:
       // `takeAllPeripherals` already treats an unreachable peer as "the

--- a/Magic Switch/Info.plist
+++ b/Magic Switch/Info.plist
@@ -20,6 +20,17 @@
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>magicswitch</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Magic Switch/Model/Entity/BluetoothPeripheral.swift
+++ b/Magic Switch/Model/Entity/BluetoothPeripheral.swift
@@ -15,6 +15,17 @@ enum PeripheralConnectionState: Equatable {
   case connected
 }
 
+/// Which way a switch should move a peripheral (or the full set). `toggle` is
+/// the menu-click behavior: move it to whichever Mac doesn't have it. `take`
+/// and `send` exist for scripted triggers (the `magicswitch://` URL scheme),
+/// where idempotence matters — a hotkey bound to "bring the trackpad here"
+/// pressed twice must be a no-op, not bounce the trackpad back.
+enum SwitchDirection: String {
+  case take
+  case send
+  case toggle
+}
+
 /// Represents a Bluetooth peripheral device with its connection state and identity information
 struct BluetoothPeripheral: Identifiable, Codable, Equatable {
   // MARK: - Properties

--- a/Magic Switch/Model/Entity/SwitchURLCommand.swift
+++ b/Magic Switch/Model/Entity/SwitchURLCommand.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+/// Why a `magicswitch://` URL couldn't be parsed or resolved. `message` is the
+/// user-facing text for the failure notification — an external trigger (a
+/// hotkey, a script) has no UI of its own, so a notification is the only
+/// feedback channel.
+enum URLCommandError: Error {
+  case unknownCommand(String)
+  case unknownParameter(String)
+  case invalidDirection(String)
+  case emptyPeripheral
+  case noMatch(String)
+
+  var message: String {
+    switch self {
+    case .unknownCommand(let url):
+      return "Unrecognized command URL '\(url)'. The only command is magicswitch://switch."
+    case .unknownParameter(let name):
+      return "Unknown parameter '\(name)'. Supported: 'peripheral' and 'direction'."
+    case .invalidDirection(let value):
+      return "Invalid direction '\(value)'. Use 'take', 'send', or 'toggle'."
+    case .emptyPeripheral:
+      return "'peripheral' needs a value: a type (e.g. 'trackpad'), a name, or a MAC address."
+    case .noMatch(let selector):
+      return "No registered peripheral matches '\(selector)'."
+    }
+  }
+}
+
+/// A parsed `magicswitch://switch` URL — the app's external-control surface.
+/// Anything that can open a URL (a hotkey utility, a mouse-button macro,
+/// `open -g` in a script) can trigger the same switches as the dropdown:
+///
+///     magicswitch://switch                             toggle the full set
+///     magicswitch://switch?direction=take              bring the full set here
+///     magicswitch://switch?peripheral=trackpad&direction=take
+///     magicswitch://switch?peripheral=trackpad&peripheral=mouse
+///
+/// Parsing is strict: an unknown command or parameter fails the whole URL
+/// rather than degrading — a typo like `perpheral=` must not silently become
+/// a full-set switch. This type only parses and resolves; execution lives in
+/// `AppDelegate.handleCommandURL`.
+struct SwitchURLCommand {
+  /// How one `peripheral=` value picks registered peripherals. Classified at
+  /// parse time, most-specific reading first — MAC address, else type
+  /// keyword, else display name — so a peripheral literally named "Mouse"
+  /// can still be pinned down by its address.
+  enum PeripheralSelector {
+    /// Exact `BluetoothPeripheral.id` (IOBluetooth's "aa-bb-cc-dd-ee-ff"), lowercased.
+    case address(String)
+    /// Every registered peripheral whose resolved type matches.
+    case type(PeripheralType)
+    /// Every registered peripheral with this display name, case-insensitively.
+    case name(String)
+
+    /// The value as the caller wrote it, for "no match" error text.
+    var label: String {
+      switch self {
+      case .address(let address): return address
+      case .type(let type): return type.rawValue
+      case .name(let name): return name
+      }
+    }
+
+    func matches(_ peripheral: BluetoothPeripheral, in store: BluetoothPeripheralStore) -> Bool {
+      switch self {
+      case .address(let address):
+        return peripheral.id.lowercased() == address
+      case .type(let type):
+        return store.peripheralType(for: peripheral) == type
+      case .name(let name):
+        return peripheral.name.caseInsensitiveCompare(name) == .orderedSame
+      }
+    }
+  }
+
+  let direction: SwitchDirection
+  /// Empty means the whole registered set.
+  let selectors: [PeripheralSelector]
+
+  static func parse(_ url: URL) -> Result<SwitchURLCommand, URLCommandError> {
+    guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+      components.host == "switch",
+      components.path.isEmpty || components.path == "/"
+    else {
+      return .failure(.unknownCommand(url.absoluteString))
+    }
+    var direction = SwitchDirection.toggle
+    var selectors: [PeripheralSelector] = []
+    for item in components.queryItems ?? [] {
+      switch item.name {
+      case "direction":
+        guard let value = item.value, let parsed = SwitchDirection(rawValue: value) else {
+          return .failure(.invalidDirection(item.value ?? ""))
+        }
+        direction = parsed
+      case "peripheral":
+        guard let value = item.value, !value.isEmpty else {
+          return .failure(.emptyPeripheral)
+        }
+        selectors.append(classify(value))
+      default:
+        return .failure(.unknownParameter(item.name))
+      }
+    }
+    return .success(SwitchURLCommand(direction: direction, selectors: selectors))
+  }
+
+  /// Union of every selector's matches, in registration order without
+  /// duplicates. A selector that matches nothing fails the whole command —
+  /// better a "no match" notification than half a command silently acting.
+  func resolvePeripherals(
+    in store: BluetoothPeripheralStore
+  ) -> Result<[BluetoothPeripheral], URLCommandError> {
+    var seen = Set<String>()
+    var resolved: [BluetoothPeripheral] = []
+    for selector in selectors {
+      let matches = store.peripherals.filter { selector.matches($0, in: store) }
+      guard !matches.isEmpty else { return .failure(.noMatch(selector.label)) }
+      for peripheral in matches where seen.insert(peripheral.id).inserted {
+        resolved.append(peripheral)
+      }
+    }
+    return .success(resolved)
+  }
+
+  /// `.unknown` is excluded from the type keywords: "unknown" as a selector
+  /// is far likelier a typo than a request for every unclassified device.
+  private static func classify(_ value: String) -> PeripheralSelector {
+    // Same shape check as `BluetoothPeripheral`'s decoder: the MAC address as
+    // formatted by `IOBluetoothDevice.addressString`.
+    if value.range(of: "^([0-9A-Fa-f]{2}-){5}[0-9A-Fa-f]{2}$", options: .regularExpression) != nil {
+      return .address(value.lowercased())
+    }
+    if let type = PeripheralType(rawValue: value.lowercased()), type != .unknown {
+      return .type(type)
+    }
+    return .name(value)
+  }
+}

--- a/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
+++ b/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
@@ -621,6 +621,45 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
     print("\(peripheral.name) has been removed from the list")
   }
 
+  /// Moves `peripheral` per `direction`. `toggle` is the dropdown row's click
+  /// behavior: send it if it's on this Mac, take it if it isn't. `take` and
+  /// `send` skip a peripheral that's already on the right Mac, so scripted
+  /// triggers can repeat them safely. Any direction is ignored mid-handoff.
+  /// Falls back to a plain local pair when there's no switchable peer to take
+  /// from.
+  func switchPeripheral(_ peripheral: BluetoothPeripheral, direction: SwitchDirection) {
+    let networkStore = NetworkDeviceStore.shared
+    let canSwitch = networkStore.networkDevices.contains { networkStore.isSwitchable($0) }
+    switch connectionState(for: peripheral.id) {
+    case .connected:
+      guard direction != .take else { return }
+      // The dropdown greys out a connected row when no Mac is reachable, and
+      // for the same reason a scripted send must refuse here: with no peer to
+      // hand to, `sendPeripheralToPeer` falls back to a plain local release,
+      // stranding the peripheral on neither Mac. The fixed identifier
+      // collapses a multi-peripheral command into one notification.
+      guard canSwitch else {
+        NotificationManager.showNotification(
+          title: "Can't Switch",
+          body: "The other Mac isn't reachable — keeping peripherals on this Mac.",
+          identifier: "switch-no-peer"
+        )
+        return
+      }
+      sendPeripheralToPeer(peripheral)
+    case .disconnected:
+      guard direction != .send else { return }
+      if canSwitch {
+        takePeripheralFromPeer(peripheral)
+      } else {
+        // No peer to ask — pair it to this Mac directly over Bluetooth.
+        connectPeripheral(peripheral)
+      }
+    case .connecting, .releasing:
+      break  // handoff in flight
+    }
+  }
+
   /// Asks the peer to release just this peripheral, then pairs it
   /// locally. Used by the Peripheral tab's "Connect to PC" button and by
   /// the right-click menu's per-peripheral switch. Apple's Magic devices

--- a/Magic Switch/View/MenuBar/DropdownContentView.swift
+++ b/Magic Switch/View/MenuBar/DropdownContentView.swift
@@ -284,7 +284,9 @@ final class DropdownContentView: NSView {
   private func makePeripheralRow(_ peripheral: BluetoothPeripheral) -> NSView {
     let state = bluetoothStore.connectionState(for: peripheral.id)
     let canSwitch = networkStore.networkDevices.contains { networkStore.isSwitchable($0) }
-    let row = MenuRowControl { [weak self] in self?.togglePeripheral(peripheral) }
+    let row = MenuRowControl { [weak self] in
+      self?.bluetoothStore.switchPeripheral(peripheral, direction: .toggle)
+    }
     // A disconnected peripheral is always clickable — take it (locally over
     // Bluetooth if there's no peer to ask). A connected one can only be *sent*,
     // so it greys out when no Mac is reachable to hand it to. A pairing row is
@@ -388,25 +390,6 @@ final class DropdownContentView: NSView {
     content.addArrangedSubview(spacer())
     row.toolTip = "A newer version of Magic Switch is available. Opens the release page."
     return clickableRow(row, content: content)
-  }
-
-  // MARK: - Actions
-
-  private func togglePeripheral(_ peripheral: BluetoothPeripheral) {
-    let canSwitch = networkStore.networkDevices.contains { networkStore.isSwitchable($0) }
-    switch bluetoothStore.connectionState(for: peripheral.id) {
-    case .connected:
-      bluetoothStore.sendPeripheralToPeer(peripheral)
-    case .disconnected:
-      if canSwitch {
-        bluetoothStore.takePeripheralFromPeer(peripheral)
-      } else {
-        // No peer to ask — pair it to this Mac directly over Bluetooth.
-        bluetoothStore.connectPeripheral(peripheral)
-      }
-    case .connecting, .releasing:
-      break  // handoff in flight
-    }
   }
 
   // MARK: - Building blocks

--- a/README.md
+++ b/README.md
@@ -97,6 +97,24 @@ On the **Device** tab, find the other Mac under **Connected Devices** and click 
 
 The menu-bar icon also signals state: a **warning triangle** means Magic Switch needs attention (not paired, or Bluetooth off/denied) — hover for the reason; **up/down arrows** flash briefly while peripherals are moving between Macs (the dropdown is pictured at the top of this README).
 
+### Trigger switches from anything (URL scheme)
+
+Magic Switch registers the `magicswitch://` URL scheme, so anything that can open a URL — a hotkey utility (Raycast, BetterTouchTool, skhd), a mouse-button macro, the Shortcuts app, a shell script — can trigger the same switches as the menu:
+
+```bash
+open -g "magicswitch://switch"                                      # everything — same as clicking the other Mac in the menu
+open -g "magicswitch://switch?direction=take"                       # bring everything to this Mac
+open -g "magicswitch://switch?peripheral=trackpad&direction=take"   # just the trackpad(s)
+open -g "magicswitch://switch?peripheral=trackpad&peripheral=mouse" # repeat peripheral= for several
+```
+
+(`-g` keeps your current app focused.) Parameters:
+
+- `peripheral` *(repeatable)* — which peripherals to move; omit it for the whole registered set. Each value is matched as a MAC address (`aa-bb-cc-dd-ee-ff`), else as a type keyword (`keyboard`, `mouse`, `trackpad`, `headphones`, `airpods`, `microphone`), else as a device name (case-insensitive).
+- `direction` — `take` (bring to this Mac), `send` (move to the other Mac), or `toggle` (the default: move each to whichever Mac doesn't have it, exactly like a menu click). `take` and `send` are idempotent, so they're the ones to bind to hotkeys — repeating one is a no-op instead of bouncing peripherals back.
+
+Run the command on the Mac that should act. `direction=take` works even while the other Mac is asleep or off the network — an unreachable Mac isn't holding the peripherals anymore, so they're grabbed directly. Errors (a mistyped parameter, a peripheral that matches nothing) surface as notifications, and anything mid-handoff is left alone.
+
 ## Updates
 
 Magic Switch tells you when there's a new version — it never updates itself. About once a day it makes a single anonymous request to GitHub's public releases API for [this repo](https://github.com/MegaManSec/magic-switch/releases) and compares your installed version with the latest published release; no account, sign-in, or telemetry is involved. When a newer version exists, an **Update Available** notice (with the new version number) appears at the top of the right-click menu and in **Settings → Other** — clicking it opens the release page so you can download and install it yourself. A failed check (offline, rate-limited, etc.) is retried about hourly; otherwise checks happen at most once every 24 hours. Your installed version is always shown in **Settings → Other**.


### PR DESCRIPTION
Closes #55.

Registers the `magicswitch://` URL scheme so anything that can open a URL — a hotkey utility, a mouse-button macro (#55's actions-ring use case), Shortcuts, a shell script — can trigger the same switches as the menu, without growing the app itself:

```bash
open -g "magicswitch://switch"                                      # toggle everything, like clicking the other Mac
open -g "magicswitch://switch?direction=take"                       # bring everything to this Mac (idempotent)
open -g "magicswitch://switch?peripheral=trackpad&direction=take"   # just the trackpad
open -g "magicswitch://switch?peripheral=trackpad&peripheral=mouse" # several at once
```

- `peripheral` (repeatable) matches a MAC address, else a type keyword (`keyboard`/`mouse`/`trackpad`/…), else a device name; omitted means the full registered set.
- `direction=take|send|toggle` (default `toggle`). `take`/`send` are idempotent so repeated hotkey presses are no-ops instead of bouncing peripherals back.

Implementation:
- `SwitchURLCommand` (new entity) parses and resolves URLs; parsing is strict, so a typo'd parameter fails with a notification rather than degrading into a full-set switch.
- The dropdown's per-peripheral toggle moves into `BluetoothPeripheralStore.switchPeripheral(_:direction:)`; the menu row now calls it with `.toggle`. It also refuses a send when no peer is reachable (mirroring the greyed-out row) so a scripted send can't strand a peripheral on neither Mac.
- The display trigger's full-set take is extracted into `takeAllPeripheralsIfAway`, shared with the URL scheme's full-set `take` — so `take` works even while the other Mac is asleep. Full-set `send`/`toggle` reuse the menu's health-checked `performSwitch` path, which gained a `direction` parameter.
- All errors surface via `NotificationManager`; anything mid-handoff is ignored, same as the menu.

Docs: README gains a "Trigger switches from anything (URL scheme)" section under Usage.