### PR TITLE
feat: rename the Device tab to Macs and polish its Trust and Sync aff…

### DIFF
--- a/Magic Switch/AppDelegate/AppDelegate.swift
+++ b/Magic Switch/AppDelegate/AppDelegate.swift
@@ -426,7 +426,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
       guard let device = networkStore.networkDevices.first else {
         NotificationManager.showNotification(
           title: "Can't Switch",
-          body: "No Mac is registered — pick one in Settings → Device.",
+          body: "No Mac is registered — pick one in Settings → Macs.",
           identifier: "url-command-no-device")
         return
       }

--- a/Magic Switch/Model/Store/NetworkDeviceStore.swift
+++ b/Magic Switch/Model/Store/NetworkDeviceStore.swift
@@ -84,7 +84,7 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
   private var pendingFastRecheck: Set<String> = []
 
   /// In-flight Ping/Sync per device id. Set when the user taps Ping/Sync on the
-  /// Device tab and cleared when the op finishes; the view both disables the
+  /// Macs tab and cleared when the op finishes; the view both disables the
   /// buttons and renders the "Pinging…/Syncing…" line off this, so they survive
   /// leaving and re-entering the tab (the view's own `@State` wouldn't).
   @Published private(set) var inFlightOperations: [String: DeviceOperation] = [:]
@@ -137,7 +137,7 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
     // Don't drop from `discoveredNetworkDevices`; `availableNetworkDevices`
     // filters by `!networkDevices.contains` at read time. Dropping here
     // would mean `removeNetworkDevice` can't re-surface the Mac under
-    // "Available Devices" until the next Bonjour resolution.
+    // "Macs Found on the Network" until the next Bonjour resolution.
     networkDevices.append(device)
     saveNetworkDevices()
   }
@@ -163,7 +163,7 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
         NotificationManager.showNotification(
           title: "Identity Mismatch",
           body:
-            "\(device.name) is advertising a new pairing key. Open Settings → Device and choose Trust if you re-paired the other Mac yourself.",
+            "\(device.name) is advertising a new pairing key. Open Settings → Macs and choose Trust if you re-paired the other Mac yourself.",
           identifier: "identity-mismatch-\(device.id)"
         )
       }
@@ -607,7 +607,7 @@ extension NetworkDeviceStore {
 extension NetworkDeviceStore {
   /// Push this Mac's registered peripheral list to `device`. Completion
   /// receives the categorised outgoing result so the caller can render
-  /// inline UI feedback (the Device tab does this under each row). The
+  /// inline UI feedback (the Macs tab does this under each row). The
   /// store no longer surfaces its own notifications for sync — callers
   /// decide how to report success/failure.
   func sendPeripheralSync(

--- a/Magic Switch/View/Settings/NetworkDeviceManagementView.swift
+++ b/Magic Switch/View/Settings/NetworkDeviceManagementView.swift
@@ -11,14 +11,14 @@ struct OperationResult {
 
 private enum Constants {
   enum Strings {
-    static let connectedDevices = "Connected Devices"
-    static let availableDevices = "Available Devices"
+    static let connectedDevices = "Your Other Mac"
+    static let availableDevices = "Macs Found on the Network"
     static let noConnectedDevicesHint =
-      "Add another Mac from \"Available Devices\" below to start switching peripherals between them."
+      "Add your other Mac from \"Macs Found on the Network\" below to start switching peripherals between them."
     static let noAvailableDevicesHint =
       "Make sure Magic Switch is running on your other Mac and both Macs are on the same Wi-Fi network. Then tap Refresh."
     static let connectionLimitMessage =
-      "Only one device can be connected at a time. Remove the existing device first."
+      "Only one Mac can be connected at a time. Remove the existing one first."
     static let notify = "Ping"
     static let add = "Add"
   }
@@ -39,7 +39,7 @@ struct NetworkDeviceManagementView: View {
   /// the trash button looked like a no-op. One enum-keyed alert avoids that.
   @State private var activeAlert: DeviceAlert?
 
-  /// The two confirmation prompts the Device tab can raise. `id` is unique
+  /// The two confirmation prompts the Macs tab can raise. `id` is unique
   /// per (kind, device) so re-triggering for a different device re-presents.
   private enum DeviceAlert: Identifiable {
     case remove(NetworkDevice)
@@ -108,7 +108,7 @@ struct NetworkDeviceManagementView: View {
         return Alert(
           title: Text("Remove \(device.name)?"),
           message: Text(
-            "It will be removed from your registered list. You can add it again from Available Devices."
+            "It will be removed from your registered list. You can add it again from \"Macs Found on the Network\"."
           ),
           primaryButton: .destructive(Text("Remove")) {
             networkStore.removeNetworkDevice(device: device)
@@ -118,9 +118,7 @@ struct NetworkDeviceManagementView: View {
       case .trust(let device):
         return Alert(
           title: Text("Trust new pairing key for \(device.name)?"),
-          message: Text(
-            "Only do this if you intentionally re-paired the other Mac. Otherwise this could be an impersonation attempt — the fingerprint that previously identified \(device.name) has changed."
-          ),
+          message: Text(trustAlertMessage(for: device)),
           primaryButton: .destructive(Text("Trust")) {
             networkStore.trustPendingFingerprint(for: device.id)
           },
@@ -128,6 +126,24 @@ struct NetworkDeviceManagementView: View {
         )
       }
     }
+  }
+
+  /// Show both fingerprints so the "verify this was intentional" step can
+  /// actually be performed: the new one should match what the other Mac's
+  /// Pairing tab shows after the re-pair. Fingerprints are short hex strings
+  /// (see `PairingStore.fingerprint(forKey:)`), fine for an alert body.
+  private func trustAlertMessage(for device: NetworkDevice) -> String {
+    var message =
+      "Only do this if you intentionally re-paired the other Mac. Otherwise this could be an impersonation attempt — the fingerprint that previously identified \(device.name) has changed."
+    if let pending = device.pendingFingerprint {
+      message += "\n\nNew fingerprint: \(pending)"
+      if let pinned = device.fingerprint {
+        message += "\nPrevious fingerprint: \(pinned)"
+      }
+      message +=
+        "\n\nThe new fingerprint should match the one shown in Settings → Pairing on \(device.name)."
+    }
+    return message
   }
 
   // MARK: - Tooltips
@@ -349,8 +365,10 @@ private struct NetworkDeviceListView: View {
           .help(blockedByPairing ? NetworkDeviceManagementView.Help.needsPairing : actionHelp)
 
           if let onSync = onSyncPeripherals {
+            // Not `square.and.arrow.up` — that's the system Share glyph, which
+            // misreads as a share sheet. Circular arrows say "sync".
             Button(action: { onSync(device) }) {
-              Image(systemName: "square.and.arrow.up")
+              Image(systemName: "arrow.triangle.2.circlepath")
                 .foregroundColor(.blue)
             }
             .disabled(!device.isActive || blockedByPairing || inFlight != nil)

--- a/Magic Switch/View/Settings/PairingSettingsView.swift
+++ b/Magic Switch/View/Settings/PairingSettingsView.swift
@@ -77,11 +77,11 @@ struct PairingSettingsView: View {
         .font(.title2)
         .bold()
       if networkStore.networkDevices.isEmpty {
-        // Mirrors the prerequisite hint on the Device tab — accent-coloured
+        // Mirrors the prerequisite hint on the Macs tab — accent-coloured
         // Label so the "do this next" affordance reads as actionable
         // instead of looking like throwaway helper text.
         Label(
-          "Now pick the other Mac in Settings → Device to start switching.",
+          "Now pick the other Mac in Settings → Macs to start switching.",
           systemImage: "arrow.right.circle.fill"
         )
         .font(.callout.bold())

--- a/Magic Switch/View/Settings/SettingsView.swift
+++ b/Magic Switch/View/Settings/SettingsView.swift
@@ -8,7 +8,7 @@ struct SettingsView: View {
   private enum TabItem {
     /// Configuration for each tab
     static let devices = (image: "keyboard", text: "Peripheral")
-    static let mac = (image: "desktopcomputer", text: "Device")
+    static let mac = (image: "desktopcomputer", text: "Macs")
     static let pairing = (image: "lock.shield", text: "Pairing")
     static let other = (image: "ellipsis.circle", text: "Other")
   }

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ Tick the Magic devices you want Magic Switch to hand back and forth. Each row's 
   <em>That leading icon is also a picker — Magic Switch auto-detects the type (keyboard, mouse, trackpad, headphones, AirPods, microphone), and you can override it or set it back to Automatic.</em>
 </p>
 
-### 3. Device tab — pick the other Mac
+### 3. Macs tab — pick the other Mac
 
-Choose the other Mac under **Available Devices**. It shows up once it's on the same network running Magic Switch; a greyed-out row means it isn't reachable right now.
+Choose the other Mac under **Macs Found on the Network**. It shows up once it's on the same network running Magic Switch; a greyed-out row means it isn't reachable right now.
 
 <p align="center">
-  <img src="docs/assets/device-tab.png" alt="Device tab showing the connected Mac and available devices" width="600"><br>
-  <em>Device tab — pick the other Mac, sync peripherals to it, and check it's reachable.</em>
+  <img src="docs/assets/device-tab.png" alt="Macs tab showing the connected Mac and available Macs" width="600"><br>
+  <em>Macs tab — pick the other Mac, sync peripherals to it, and check it's reachable.</em>
 </p>
 
 ### 4. Pairing tab — link the two Macs (required)
@@ -75,7 +75,7 @@ Generate a twelve-character code on one Mac and enter it on the other; either di
 
 ### 5. Sync your peripherals to the other Mac
 
-On the **Device** tab, find the other Mac under **Connected Devices** and click its **Share** button (the box-with-an-up-arrow, beside **Ping**). A "Synced N peripherals to …" line confirms it. The button is greyed out while that Mac is offline.
+On the **Macs** tab, find the other Mac under **Your Other Mac** and click its **Sync** button (the circular arrows, beside **Ping**). A "Synced N peripherals to …" line confirms it. The button is greyed out while that Mac is offline.
 
 ### Other tab — preferences
 
@@ -125,8 +125,8 @@ Magic Switch tells you when there's a new version — it never updates itself. A
 - Devices powered on; Bluetooth enabled.
 - Same network; not blocked by firewall.
 - Bluetooth and Local Network permissions granted in System Settings → Privacy & Security.
-- A **greyed-out device** — in the Device tab or the right-click menu — means it isn't reachable on the network right now (the other Mac is asleep, off Wi-Fi, or not running Magic Switch). Ping, Sync, and switching stay disabled until it's back online.
-- On the **Device** tab, **Ping** tests whether the two Macs can reach each other over the secure channel.
+- A **greyed-out device** — in the Macs tab or the right-click menu — means it isn't reachable on the network right now (the other Mac is asleep, off Wi-Fi, or not running Magic Switch). Ping, Sync, and switching stay disabled until it's back online.
+- On the **Macs** tab, **Ping** tests whether the two Macs can reach each other over the secure channel.
 - **Closing or sleeping one Mac hands its peripherals to the other.** When this Mac sleeps (or you close its lid), it hands the peripherals it holds to your other Mac — or, if that Mac isn't reachable yet, frees them so it can pick them up the moment it wakes. That's why you can close one Mac and find the keyboard and mouse already on the other. This is on by default; you can turn it off under **Settings → Other → "Release peripherals when this Mac sleeps."**
 - **A peripheral didn't come back after sleep or a lid-close.** Apple's Magic devices sometimes get stuck once the Bluetooth radio sleeps and won't reconnect — even a manual reconnect fails until you switch the peripheral **off and on** with its power switch. Magic Switch keeps watching for anything that was on this Mac before it slept: the moment the device reappears (which a power-cycle triggers), it reconnects automatically — as long as your other Mac isn't actively using it. This is on by default; you can turn it off under **Settings → Other → "Reconnect peripherals if they drop."**
 - **Both Macs slept, and now a peripheral connects to neither.** When this Mac sleeps, it frees its peripherals for your other Mac to take (see above). If the other Mac never takes them — it was asleep too, or off the network the whole time — they end up attached to no Mac at all, and a Magic device in that state stops listening for connections after a short while; no Mac can reach it until it's woken up. When this Mac wakes it immediately tries to grab everything it freed, so a round trip usually recovers on its own — clicking or pressing a key on the peripheral within the first minute after opening the lid helps it get caught. If a peripheral still won't respond, this is the one situation where you have to help: flick its power switch **off and on**, and Magic Switch reconnects it the moment it comes back up. If that trade-off doesn't suit how you use your Macs, turn off **Settings → Other → "Release peripherals when this Mac sleeps"** — peripherals then stay bonded to this Mac across sleep (and reconnect instantly on wake), at the cost of the other Mac needing the same power-cycle help if you switch desks while this Mac sleeps.
@@ -184,7 +184,7 @@ Two Macs discover each other over Bonjour, then exchange short commands over a s
 
 The LAN channel uses a shared symmetric key derived from the twelve-character pairing code via PBKDF2-HMAC-SHA256 (600k iterations) and stored in the Keychain. Per connection, both sides exchange a 32-byte nonce and derive direction-specific session keys via HKDF; messages are framed as length-prefixed ChaCha20-Poly1305 sealed boxes with monotonic counter nonces. Failed authentications are rate-limited per source IP (5 failures / 60s → 15-minute block), and the client side backs off after 5 failed outgoing attempts in the same window.
 
-Each Mac pins the other's key fingerprint the first time it sees it (trust on first use). If a later advertisement carries a *different* fingerprint, that peer is dropped and the Device tab makes you explicitly **Trust** the new identity before switching resumes — so a key change or impersonation attempt is surfaced rather than silently accepted.
+Each Mac pins the other's key fingerprint the first time it sees it (trust on first use). If a later advertisement carries a *different* fingerprint, that peer is dropped and the Macs tab makes you explicitly **Trust** the new identity before switching resumes — so a key change or impersonation attempt is surfaced rather than silently accepted.
 
 Known limits:
 - The build isn't code-signed or notarized.


### PR DESCRIPTION
…ordances

- Tab is now "Macs"; sections are "Your Other Mac" and "Macs Found on the Network" — "Device" was ambiguous next to a Peripheral tab, and every string that referenced the old names follows suit.
- The Trust alert now shows the new and previously pinned fingerprints so the "verify this was intentional" step can actually be performed.
- The Sync button uses a sync glyph instead of the system Share glyph.