### PR TITLE
feat: global keyboard shortcuts for full-set switches

### DIFF
--- a/Magic Switch.xcodeproj/project.pbxproj
+++ b/Magic Switch.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		0A00001000000000000000B4 /* OutgoingConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00001000000000000000A4 /* OutgoingConnection.swift */; };
 		0A00001000000000000000B5 /* RateLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00001000000000000000A5 /* RateLimiter.swift */; };
 		0A00002000000000000000B6 /* UpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00002000000000000000A6 /* UpdateChecker.swift */; };
+		0A00006000000000000000BB /* HotkeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00006000000000000000AB /* HotkeyManager.swift */; };
 		0A00001000000000000000B6 /* PairingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00001000000000000000A6 /* PairingSettingsView.swift */; };
 		076AB2202CE9D690004D45F0 /* BluetoothPeripheral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076AB2002CE9D690004D45F0 /* BluetoothPeripheral.swift */; };
 		0A00005000000000000000B9 /* SwitchURLCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00005000000000000000A9 /* SwitchURLCommand.swift */; };
@@ -45,6 +46,7 @@
 		076AB1F82CE9D690004D45F0 /* NetworkDevice+HealthCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkDevice+HealthCheck.swift"; sourceTree = "<group>"; };
 		076AB1FA2CE9D690004D45F0 /* BluetoothManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothManager.swift; sourceTree = "<group>"; };
 		076AB1FC2CE9D690004D45F0 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
+		0A00006000000000000000AB /* HotkeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManager.swift; sourceTree = "<group>"; };
 		076AB1FD2CE9D690004D45F0 /* ServiceBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceBrowser.swift; sourceTree = "<group>"; };
 		076AB1FE2CE9D690004D45F0 /* ServicePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServicePublisher.swift; sourceTree = "<group>"; };
 		0A00003000000000000000A7 /* SleepMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepMonitor.swift; sourceTree = "<group>"; };
@@ -117,6 +119,7 @@
 				0A00001000000000000000A4 /* OutgoingConnection.swift */,
 				0A00001000000000000000A5 /* RateLimiter.swift */,
 				0A00002000000000000000A6 /* UpdateChecker.swift */,
+				0A00006000000000000000AB /* HotkeyManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -294,6 +297,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				076AB2172CE9D690004D45F0 /* AppDelegate.swift in Sources */,
+				0A00006000000000000000BB /* HotkeyManager.swift in Sources */,
 				076AB2182CE9D690004D45F0 /* Magic_SwitchApp.swift in Sources */,
 				076AB2192CE9D690004D45F0 /* IOBluetoothDevice+Extension.swift in Sources */,
 				076AB21A2CE9D690004D45F0 /* NetworkDevice+HealthCheck.swift in Sources */,

--- a/Magic Switch/AppDelegate/AppDelegate.swift
+++ b/Magic Switch/AppDelegate/AppDelegate.swift
@@ -71,6 +71,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     setupPingFlashObserver()
     setupTransferObservers()
     setupDisplayTrigger()
+    setupHotkey()
     // Best-effort, silent, throttled to once per 24h. Drives the "Update
     // Available" affordances in the right-click menu and Settings → Other.
     UpdateChecker.shared.checkIfNeeded()
@@ -578,6 +579,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
       self?.handleTriggerDisplaysConnected(names)
     }
     displayMonitor.start()
+  }
+
+  /// Wire the global hotkeys (Settings → Other) to the full-set switch paths
+  /// — one optional shortcut per direction, with the URL scheme's semantics:
+  /// `send` and `take` are idempotent, `toggle` mirrors a menu click.
+  private func setupHotkey() {
+    HotkeyManager.shared.onHotkey = { [weak self] direction in
+      self?.performFullSetCommand(direction)
+    }
+    HotkeyManager.shared.start()
   }
 
   /// A trigger display just connected (runs on main). Announce it, then take

--- a/Magic Switch/Manager/HotkeyManager.swift
+++ b/Magic Switch/Manager/HotkeyManager.swift
@@ -1,0 +1,265 @@
+import AppKit
+import Carbon.HIToolbox
+
+/// A recorded global keyboard shortcut: the key plus its modifiers, with a
+/// pre-computed display name for the key so rendering never needs to re-derive
+/// a glyph from the key code (layout-dependent and fiddly at load time).
+struct HotkeyShortcut: Codable, Equatable {
+  let keyCode: UInt32
+  /// `NSEvent.ModifierFlags.rawValue`, masked to device-independent flags.
+  let modifierFlags: UInt
+  /// Display name of the key alone, e.g. "K", "Space", "F5".
+  let keyDisplay: String
+
+  var modifiers: NSEvent.ModifierFlags {
+    NSEvent.ModifierFlags(rawValue: modifierFlags)
+  }
+
+  /// Standard macOS ordering: ⌃ ⌥ ⇧ ⌘, then the key.
+  var displayString: String {
+    var parts = ""
+    if modifiers.contains(.control) { parts += "⌃" }
+    if modifiers.contains(.option) { parts += "⌥" }
+    if modifiers.contains(.shift) { parts += "⇧" }
+    if modifiers.contains(.command) { parts += "⌘" }
+    return parts + keyDisplay
+  }
+
+  /// The same modifiers in Carbon's bit layout, for `RegisterEventHotKey`.
+  var carbonModifiers: UInt32 {
+    var carbon: UInt32 = 0
+    if modifiers.contains(.command) { carbon |= UInt32(cmdKey) }
+    if modifiers.contains(.option) { carbon |= UInt32(optionKey) }
+    if modifiers.contains(.control) { carbon |= UInt32(controlKey) }
+    if modifiers.contains(.shift) { carbon |= UInt32(shiftKey) }
+    return carbon
+  }
+}
+
+/// Owns the app's global hotkeys end to end: persistence, Carbon
+/// registration, and the record-a-new-shortcut flow driven from Settings →
+/// Other. One optional shortcut per `SwitchDirection` — the same three
+/// full-set actions as the URL scheme, with the same semantics (`send` and
+/// `take` are idempotent; `toggle` mirrors clicking the Mac row in the menu).
+///
+/// Carbon `RegisterEventHotKey` is used deliberately: unlike a global NSEvent
+/// monitor it needs no Accessibility/Input Monitoring permission and works in
+/// the App Sandbox. Recording uses a *local* monitor (only sees this app's own
+/// key events, no permission needed) while the Settings window is key.
+final class HotkeyManager: ObservableObject {
+  static let shared = HotkeyManager()
+
+  /// The registered shortcuts; a missing key means that action has none.
+  @Published private(set) var shortcuts: [SwitchDirection: HotkeyShortcut] = [:]
+
+  /// The action whose shortcut is being recorded, nil when not recording.
+  @Published private(set) var recordingDirection: SwitchDirection?
+
+  /// Fired on the main queue when a hotkey is pressed. Assigned by
+  /// `AppDelegate`, which routes it into the full-set switch path.
+  var onHotkey: ((SwitchDirection) -> Void)?
+
+  /// Stable order so each direction keeps its Carbon hotkey ID (index + 1).
+  private static let directions: [SwitchDirection] = [.send, .take, .toggle]
+
+  private static func defaultsKey(for direction: SwitchDirection) -> String {
+    "switch-shortcut-\(direction.rawValue)"
+  }
+
+  private var hotKeyRefs: [SwitchDirection: EventHotKeyRef] = [:]
+  private var eventHandlerRef: EventHandlerRef?
+  private var recordingMonitor: Any?
+
+  private init() {}
+
+  /// Load the persisted shortcuts (if any) and register them. Call once at launch.
+  func start() {
+    for direction in Self.directions {
+      guard let data = UserDefaults.standard.data(forKey: Self.defaultsKey(for: direction)),
+        let stored = try? JSONDecoder().decode(HotkeyShortcut.self, from: data)
+      else { continue }
+      shortcuts[direction] = stored
+    }
+    syncRegistration()
+  }
+
+  /// Persist and activate `newShortcut` for `direction`; nil turns it off.
+  /// A chord already bound to another action moves here (recording a taken
+  /// chord means "rebind it", the way macOS's own shortcut panes behave).
+  func setShortcut(_ newShortcut: HotkeyShortcut?, for direction: SwitchDirection) {
+    if let newShortcut {
+      for (other, existing) in shortcuts where other != direction && existing == newShortcut {
+        shortcuts[other] = nil
+        UserDefaults.standard.removeObject(forKey: Self.defaultsKey(for: other))
+      }
+    }
+    shortcuts[direction] = newShortcut
+    if let newShortcut, let data = try? JSONEncoder().encode(newShortcut) {
+      UserDefaults.standard.set(data, forKey: Self.defaultsKey(for: direction))
+    } else {
+      UserDefaults.standard.removeObject(forKey: Self.defaultsKey(for: direction))
+    }
+    syncRegistration()
+  }
+
+  // MARK: - Recording
+
+  /// Start capturing the next key press as `direction`'s shortcut. Esc
+  /// cancels, Delete clears the existing shortcut, anything else needs
+  /// ⌘/⌥/⌃ (shift alone would swallow ordinary typing system-wide).
+  func startRecording(for direction: SwitchDirection) {
+    guard recordingDirection == nil else { return }
+    recordingDirection = direction
+    // While recording, every hotkey is unregistered so pressing a chord
+    // that's already bound re-records it instead of firing a switch.
+    unregisterAll()
+    recordingMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) {
+      [weak self] event in
+      guard let self = self, self.recordingDirection != nil else { return event }
+      self.handleRecordingKeyDown(event)
+      return nil  // swallow the event — it was meant for the recorder
+    }
+  }
+
+  func cancelRecording() {
+    guard recordingDirection != nil else { return }
+    stopRecording()
+  }
+
+  private func stopRecording() {
+    recordingDirection = nil
+    if let monitor = recordingMonitor {
+      NSEvent.removeMonitor(monitor)
+      recordingMonitor = nil
+    }
+    syncRegistration()
+  }
+
+  private func handleRecordingKeyDown(_ event: NSEvent) {
+    guard let direction = recordingDirection else { return }
+    let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+      .intersection([.command, .option, .control, .shift])
+
+    if event.keyCode == UInt16(kVK_Escape), modifiers.isEmpty {
+      stopRecording()
+      return
+    }
+    if event.keyCode == UInt16(kVK_Delete), modifiers.isEmpty {
+      setShortcut(nil, for: direction)
+      stopRecording()
+      return
+    }
+    // Require a real chord: at least one of ⌘/⌥/⌃.
+    guard !modifiers.intersection([.command, .option, .control]).isEmpty else { return }
+
+    let captured = HotkeyShortcut(
+      keyCode: UInt32(event.keyCode),
+      modifierFlags: modifiers.rawValue,
+      keyDisplay: Self.keyDisplay(for: event))
+    setShortcut(captured, for: direction)
+    stopRecording()
+  }
+
+  /// Human-readable name for the pressed key alone (no modifiers).
+  private static func keyDisplay(for event: NSEvent) -> String {
+    if let special = specialKeyNames[Int(event.keyCode)] { return special }
+    if let chars = event.charactersIgnoringModifiers, !chars.isEmpty {
+      return chars.uppercased()
+    }
+    return "Key \(event.keyCode)"
+  }
+
+  private static let specialKeyNames: [Int: String] = [
+    kVK_Space: "Space",
+    kVK_Return: "↩",
+    kVK_Tab: "⇥",
+    kVK_ForwardDelete: "⌦",
+    kVK_Home: "↖",
+    kVK_End: "↘",
+    kVK_PageUp: "⇞",
+    kVK_PageDown: "⇟",
+    kVK_LeftArrow: "←",
+    kVK_RightArrow: "→",
+    kVK_DownArrow: "↓",
+    kVK_UpArrow: "↑",
+    kVK_F1: "F1", kVK_F2: "F2", kVK_F3: "F3", kVK_F4: "F4",
+    kVK_F5: "F5", kVK_F6: "F6", kVK_F7: "F7", kVK_F8: "F8",
+    kVK_F9: "F9", kVK_F10: "F10", kVK_F11: "F11", kVK_F12: "F12",
+  ]
+
+  // MARK: - Carbon registration
+
+  /// Re-derive the Carbon registrations from `shortcuts`. Unregister-all then
+  /// register-all is idempotent and cheap (three hotkeys at most), which keeps
+  /// every mutation path — set, clear, steal, record — trivially correct.
+  /// No-op mid-recording; `stopRecording` calls back in when done.
+  private func syncRegistration() {
+    guard recordingDirection == nil else { return }
+    unregisterAll()
+    guard !shortcuts.isEmpty else { return }
+    installEventHandlerIfNeeded()
+    for (direction, shortcut) in shortcuts {
+      register(shortcut, for: direction)
+    }
+  }
+
+  private func register(_ shortcut: HotkeyShortcut, for direction: SwitchDirection) {
+    guard let index = Self.directions.firstIndex(of: direction) else { return }
+    // FourCharCode 'MSWH' — arbitrary but stable app-unique signature.
+    let hotKeyID = EventHotKeyID(signature: 0x4D53_5748, id: UInt32(index + 1))
+    var ref: EventHotKeyRef?
+    let status = RegisterEventHotKey(
+      shortcut.keyCode,
+      shortcut.carbonModifiers,
+      hotKeyID,
+      GetEventDispatcherTarget(),
+      0,
+      &ref)
+    if status == noErr, let ref {
+      hotKeyRefs[direction] = ref
+    } else {
+      // Most likely another app holds the same combo. The shortcut stays
+      // stored (it may work next launch); log so the silence is explainable.
+      NSLog(
+        "Magic Switch: registering global hotkey \(shortcut.displayString) failed (\(status))")
+    }
+  }
+
+  private func unregisterAll() {
+    for ref in hotKeyRefs.values {
+      UnregisterEventHotKey(ref)
+    }
+    hotKeyRefs.removeAll()
+  }
+
+  private func installEventHandlerIfNeeded() {
+    guard eventHandlerRef == nil else { return }
+    var eventType = EventTypeSpec(
+      eventClass: OSType(kEventClassKeyboard),
+      eventKind: UInt32(kEventHotKeyPressed))
+    InstallEventHandler(
+      GetEventDispatcherTarget(),
+      { _, event, userData -> OSStatus in
+        guard let userData = userData, let event = event else { return noErr }
+        var hotKeyID = EventHotKeyID()
+        GetEventParameter(
+          event,
+          EventParamName(kEventParamDirectObject),
+          EventParamType(typeEventHotKeyID),
+          nil,
+          MemoryLayout<EventHotKeyID>.size,
+          nil,
+          &hotKeyID)
+        let index = Int(hotKeyID.id) - 1
+        guard HotkeyManager.directions.indices.contains(index) else { return noErr }
+        let direction = HotkeyManager.directions[index]
+        let manager = Unmanaged<HotkeyManager>.fromOpaque(userData).takeUnretainedValue()
+        DispatchQueue.main.async { manager.onHotkey?(direction) }
+        return noErr
+      },
+      1,
+      &eventType,
+      Unmanaged.passUnretained(self).toOpaque(),
+      &eventHandlerRef)
+  }
+}

--- a/Magic Switch/View/Settings/OtherSettingsView.swift
+++ b/Magic Switch/View/Settings/OtherSettingsView.swift
@@ -8,6 +8,7 @@ struct OtherSettingsView: View {
   @Environment(\.openURL) private var openURL
   @ObservedObject private var updateChecker = UpdateChecker.shared
   @ObservedObject private var displayMonitor = DisplayMonitor.shared
+  @ObservedObject private var hotkey = HotkeyManager.shared
   @State private var launchAtLogin: Bool = false
   @AppStorage(BluetoothPeripheralStore.releaseOnSleepDefaultsKey)
   private var releaseOnSleep: Bool = true
@@ -35,6 +36,26 @@ struct OtherSettingsView: View {
           .help(
             "If a Magic peripheral that should be on this Mac drops — for example after closing the lid, or when you power-cycle a peripheral that got stuck — keep trying to reconnect it until it's back. When your other Mac goes to sleep or drops off the network, this Mac also adopts the peripherals it left behind. Magic Switch won't take a peripheral your other Mac is actively using."
           )
+      }
+      Section(header: Text("Keyboard shortcuts")) {
+        ShortcutRecorderRow(
+          direction: .send,
+          title: "Send peripherals to the other Mac",
+          help:
+            "Press anywhere in macOS to hand every registered peripheral to the other Mac. Pressing it again once they're there does nothing."
+        )
+        ShortcutRecorderRow(
+          direction: .take,
+          title: "Take peripherals to this Mac",
+          help:
+            "Press anywhere in macOS to bring every registered peripheral to this Mac — it works even while the other Mac is asleep. Pressing it again once they're here does nothing."
+        )
+        ShortcutRecorderRow(
+          direction: .toggle,
+          title: "Toggle peripherals between Macs",
+          help:
+            "Press anywhere in macOS to move the peripherals to whichever Mac doesn't have them — exactly like clicking the other Mac in the menu. Note that pressing it twice moves them there and back."
+        )
       }
       Section {
         if displayRows.isEmpty {
@@ -103,6 +124,7 @@ struct OtherSettingsView: View {
       }
     }
     .onAppear(perform: refreshOnAppear)
+    .onDisappear { hotkey.cancelRecording() }
   }
 
   var body: some View {
@@ -246,6 +268,66 @@ struct OtherSettingsView: View {
 }
 
 // MARK: - Supporting Views
+
+/// One row of the Keyboard shortcuts section: the action's name, a recorder
+/// button showing the current chord (or the record/recording prompt), and a
+/// clear button while a chord is set. Recording state lives in
+/// `HotkeyManager` so only one row can record at a time.
+private struct ShortcutRecorderRow: View {
+  let direction: SwitchDirection
+  let title: String
+  let help: String
+
+  @ObservedObject private var hotkey = HotkeyManager.shared
+
+  private var isRecording: Bool { hotkey.recordingDirection == direction }
+  private var shortcut: HotkeyShortcut? { hotkey.shortcuts[direction] }
+
+  private var buttonTitle: String {
+    if isRecording { return "Type Shortcut…" }
+    return shortcut?.displayString ?? "Record Shortcut"
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack {
+        Text(title)
+        Spacer()
+        // Clear button sits left of the recorder so the recorder buttons
+        // stay pinned to the trailing edge whether or not it's visible.
+        if shortcut != nil, !isRecording {
+          Button(action: { hotkey.setShortcut(nil, for: direction) }) {
+            Image(systemName: "xmark.circle.fill")
+              .foregroundColor(.secondary)
+          }
+          .buttonStyle(.borderless)
+          .help("Remove this shortcut.")
+          .accessibilityLabel("Remove shortcut: \(title)")
+        }
+        Button(action: toggleRecording) {
+          // Fixed-width label so the three recorder buttons form an aligned
+          // column no matter what each one currently displays.
+          Text(buttonTitle)
+            .frame(width: 130)
+        }
+        .help(help)
+      }
+      if isRecording {
+        Text("Press a key with ⌘, ⌥, or ⌃. Esc cancels; ⌫ removes the shortcut.")
+          .font(.caption)
+          .foregroundColor(.secondary)
+      }
+    }
+  }
+
+  private func toggleRecording() {
+    if isRecording {
+      hotkey.cancelRecording()
+    } else {
+      hotkey.startRecording(for: direction)
+    }
+  }
+}
 
 /// A reusable row component for settings items
 private struct SettingsRowView: View {

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ On the **Device** tab, find the other Mac under **Connected Devices** and click 
 
 ### Other tab — preferences
 
-**Launch at Login**, two peripheral-handling toggles (**Release peripherals when this Mac sleeps** and **Reconnect peripherals if they drop** — see [Troubleshooting](#troubleshooting)), a **Take peripherals when a display connects** list (mark a display to make docking this Mac to it switch your peripherals over automatically — see [Troubleshooting](#troubleshooting)), the installed version, and update notifications (see [Updates](#updates)).
+**Launch at Login**, recordable **keyboard shortcuts** that send, take, or toggle every peripheral from anywhere in macOS, two peripheral-handling toggles (**Release peripherals when this Mac sleeps** and **Reconnect peripherals if they drop** — see [Troubleshooting](#troubleshooting)), a **Take peripherals when a display connects** list (mark a display to make docking this Mac to it switch your peripherals over automatically — see [Troubleshooting](#troubleshooting)), the installed version, and update notifications (see [Updates](#updates)).
 
 <p align="center">
   <img src="docs/assets/other-tab.png" alt="Other tab showing app preferences" width="600"><br>
@@ -99,7 +99,7 @@ The menu-bar icon also signals state: a **warning triangle** means Magic Switch 
 
 ### Trigger switches from anything (URL scheme)
 
-Magic Switch registers the `magicswitch://` URL scheme, so anything that can open a URL — a hotkey utility (Raycast, BetterTouchTool, skhd), a mouse-button macro, the Shortcuts app, a shell script — can trigger the same switches as the menu:
+For the common cases — a hotkey that sends, takes, or toggles the whole set — you don't need any of this: record them under **Settings → Other → Keyboard shortcuts**. For anything fancier (per-peripheral switches, scripting), Magic Switch registers the `magicswitch://` URL scheme, so anything that can open a URL — a hotkey utility (Raycast, BetterTouchTool, skhd), a mouse-button macro, the Shortcuts app, a shell script — can trigger the same switches as the menu:
 
 ```bash
 open -g "magicswitch://switch"                                      # everything — same as clicking the other Mac in the menu


### PR DESCRIPTION
One optional, recordable shortcut per switch direction — send, take, toggle — matching the URL scheme's full-set semantics (send/take are idempotent; toggle mirrors clicking the Mac row in the menu). Carbon RegisterEventHotKey, so it needs no Accessibility permission and works in the App Sandbox; recording uses a local key monitor while Settings is key. A chord recorded on one action moves off any other action, the way macOS's own shortcut panes rebind.