### PR TITLE
feat: battery levels and VoiceOver support in the peripheral rows

### DIFF
--- a/Magic Switch.xcodeproj/project.pbxproj
+++ b/Magic Switch.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		076AB21E2CE9D690004D45F0 /* ServiceBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076AB1FD2CE9D690004D45F0 /* ServiceBrowser.swift */; };
 		076AB21F2CE9D690004D45F0 /* ServicePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076AB1FE2CE9D690004D45F0 /* ServicePublisher.swift */; };
 		0A00003000000000000000B7 /* SleepMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00003000000000000000A7 /* SleepMonitor.swift */; };
+		0A00007000000000000000BC /* PeripheralBattery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00007000000000000000AC /* PeripheralBattery.swift */; };
 		0A00004000000000000000B8 /* DisplayMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00004000000000000000A8 /* DisplayMonitor.swift */; };
 		0A00001000000000000000B1 /* SecureChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00001000000000000000A1 /* SecureChannel.swift */; };
 		0A00001000000000000000B2 /* PairingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00001000000000000000A2 /* PairingStore.swift */; };
@@ -48,6 +49,7 @@
 		076AB1FD2CE9D690004D45F0 /* ServiceBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceBrowser.swift; sourceTree = "<group>"; };
 		076AB1FE2CE9D690004D45F0 /* ServicePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServicePublisher.swift; sourceTree = "<group>"; };
 		0A00003000000000000000A7 /* SleepMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepMonitor.swift; sourceTree = "<group>"; };
+		0A00007000000000000000AC /* PeripheralBattery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeripheralBattery.swift; sourceTree = "<group>"; };
 		0A00004000000000000000A8 /* DisplayMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayMonitor.swift; sourceTree = "<group>"; };
 		0A00001000000000000000A1 /* SecureChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureChannel.swift; sourceTree = "<group>"; };
 		0A00001000000000000000A2 /* PairingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingStore.swift; sourceTree = "<group>"; };
@@ -111,6 +113,7 @@
 				076AB1FE2CE9D690004D45F0 /* ServicePublisher.swift */,
 				0A00003000000000000000A7 /* SleepMonitor.swift */,
 				0A00004000000000000000A8 /* DisplayMonitor.swift */,
+				0A00007000000000000000AC /* PeripheralBattery.swift */,
 				0A00001000000000000000A1 /* SecureChannel.swift */,
 				0A00001000000000000000A2 /* PairingStore.swift */,
 				0A00001000000000000000A3 /* IncomingConnection.swift */,
@@ -296,6 +299,7 @@
 				076AB2172CE9D690004D45F0 /* AppDelegate.swift in Sources */,
 				076AB2182CE9D690004D45F0 /* Magic_SwitchApp.swift in Sources */,
 				076AB2192CE9D690004D45F0 /* IOBluetoothDevice+Extension.swift in Sources */,
+				0A00007000000000000000BC /* PeripheralBattery.swift in Sources */,
 				076AB21A2CE9D690004D45F0 /* NetworkDevice+HealthCheck.swift in Sources */,
 				076AB21B2CE9D690004D45F0 /* BluetoothManager.swift in Sources */,
 				076AB21D2CE9D690004D45F0 /* NotificationManager.swift in Sources */,

--- a/Magic Switch/AppDelegate/AppDelegate.swift
+++ b/Magic Switch/AppDelegate/AppDelegate.swift
@@ -246,6 +246,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     // Re-read paired devices so a peripheral renamed in System Settings (and
     // its icon) refreshes in the dropdown without needing to open Settings.
     BluetoothPeripheralStore.shared.fetchConnectedPeripherals()
+    // The snapshot above only triggers a rebuild when something changed;
+    // battery levels are read at build time, so ask for one regardless.
+    dropdownContentView?.refreshRows()
     dropdownContentView?.updateFrameToFit()
   }
 

--- a/Magic Switch/Manager/PeripheralBattery.swift
+++ b/Magic Switch/Manager/PeripheralBattery.swift
@@ -1,0 +1,46 @@
+import Foundation
+import IOKit
+
+/// Reads battery levels for connected Bluetooth peripherals from the
+/// IORegistry: Apple's Magic devices publish `BatteryPercent` (alongside the
+/// device's Bluetooth `DeviceAddress`) on their HID event-service node while
+/// connected to this Mac. Read-at-render, no caching — a registry walk is
+/// cheap, and the value only exists for peripherals currently held here.
+enum PeripheralBattery {
+  /// Battery percentage (0–100) for the peripheral with the given Bluetooth
+  /// address (IOBluetooth's "aa-bb-cc-dd-ee-ff" format), or nil when the
+  /// device isn't connected to this Mac or doesn't report battery.
+  static func percent(forAddress address: String) -> Int? {
+    let wanted = normalize(address)
+    var iterator = io_iterator_t()
+    // Port 0 = default master port; the named constant for it was renamed in
+    // macOS 12 (kIOMasterPortDefault → kIOMainPortDefault) and using either
+    // spelling trips a warning on the other side of the deployment range.
+    guard
+      IOServiceGetMatchingServices(
+        0, IOServiceMatching("AppleDeviceManagementHIDEventService"), &iterator) == KERN_SUCCESS
+    else { return nil }
+    defer { IOObjectRelease(iterator) }
+
+    while case let entry = IOIteratorNext(iterator), entry != 0 {
+      defer { IOObjectRelease(entry) }
+      guard let deviceAddress = property(entry, "DeviceAddress") as? String,
+        normalize(deviceAddress) == wanted,
+        let percent = property(entry, "BatteryPercent") as? Int
+      else { continue }
+      return percent
+    }
+    return nil
+  }
+
+  private static func property(_ entry: io_registry_entry_t, _ key: String) -> Any? {
+    IORegistryEntryCreateCFProperty(entry, key as CFString, kCFAllocatorDefault, 0)?
+      .takeRetainedValue()
+  }
+
+  /// IOBluetooth formats addresses "aa-bb-cc-dd-ee-ff"; the HID registry
+  /// uses "aa:bb:cc:dd:ee:ff". Fold both to one form before comparing.
+  private static func normalize(_ address: String) -> String {
+    address.lowercased().replacingOccurrences(of: ":", with: "-")
+  }
+}

--- a/Magic Switch/View/MenuBar/DropdownContentView.swift
+++ b/Magic Switch/View/MenuBar/DropdownContentView.swift
@@ -16,6 +16,16 @@ final class MenuRowControl: NSControl {
     super.init(frame: .zero)
     wantsLayer = true
     layer?.cornerRadius = 5
+    // A custom NSControl isn't an accessibility element by default, so
+    // without this the dropdown's rows simply don't exist to VoiceOver.
+    // The row is one element (its labels/icons stay hidden from AX);
+    // callers set the label describing the row's action and state.
+    setAccessibilityElement(true)
+    setAccessibilityRole(.button)
+  }
+
+  override var isEnabled: Bool {
+    didSet { setAccessibilityEnabled(isEnabled) }
   }
 
   @available(*, unavailable)
@@ -207,6 +217,13 @@ final class DropdownContentView: NSView {
     updateFrameToFit()
   }
 
+  /// Re-render the rows on the next tick. Called when the menu opens, to
+  /// refresh values read at build time (battery levels) that no store
+  /// publisher covers. Coalesces with any store-driven rebuild.
+  func refreshRows() {
+    scheduleSync()
+  }
+
   /// Resize to fit the current content at the fixed width, so the menu measures
   /// the right item size (it changes as peripherals pair / errors appear). Width
   /// is pinned, not taken from `fittingSize`, because AppKit reports widths lazily.
@@ -278,6 +295,8 @@ final class DropdownContentView: NSView {
         ? "Finish the peripheral that's currently switching before switching them all."
         : "Switch peripherals between this Mac and \(device.name).")
       : "\(device.name) isn't reachable on the network right now."
+    row.setAccessibilityLabel(device.name)
+    row.setAccessibilityHelp(row.toolTip)
     return clickableRow(row, content: content)
   }
 
@@ -312,8 +331,15 @@ final class DropdownContentView: NSView {
       symbolView(bluetoothStore.peripheralType(for: peripheral).symbolName, color: textColor))
     top.addArrangedSubview(textLabel(peripheral.name, color: textColor))
     top.addArrangedSubview(spacer())
+    // Battery is only knowable for a peripheral currently held by this Mac
+    // (it lives in this Mac's HID registry). Read at build time; the menu
+    // rebuilds on every open (see `refreshRows`), so it stays current.
+    let battery = state == .connected ? PeripheralBattery.percent(forAddress: peripheral.id) : nil
     switch state {
     case .connected:
+      if let battery {
+        top.addArrangedSubview(caption("\(battery)%", color: .secondaryLabelColor))
+      }
       top.addArrangedSubview(symbolView("checkmark", color: .controlAccentColor))
     case .connecting:
       top.addArrangedSubview(caption("Pairing…", color: .secondaryLabelColor))
@@ -357,6 +383,17 @@ final class DropdownContentView: NSView {
         ? "Click to bring \(peripheral.name) to this Mac."
         : "Click to connect \(peripheral.name) to this Mac over Bluetooth."
     }
+    let stateSuffix: String
+    switch state {
+    case .connected: stateSuffix = ", on this Mac" + (battery.map { ", battery \($0)%" } ?? "")
+    case .connecting: stateSuffix = ", pairing"
+    case .releasing: stateSuffix = ", releasing"
+    case .disconnected: stateSuffix = ""
+    }
+    let errorSuffix = bluetoothStore.peripheralOperationError[peripheral.id]
+      .map { ", error: \($0)" } ?? ""
+    row.setAccessibilityLabel(peripheral.name + stateSuffix + errorSuffix)
+    row.setAccessibilityHelp(row.toolTip)
     return clickableRow(row, content: column)
   }
 
@@ -364,6 +401,7 @@ final class DropdownContentView: NSView {
     title: String, onClick: @escaping () -> Void
   ) -> NSView {
     let row = MenuRowControl(onClick: onClick)
+    row.setAccessibilityLabel(title)
     let content = NSStackView()
     content.orientation = .horizontal
     content.distribution = .fill
@@ -389,6 +427,8 @@ final class DropdownContentView: NSView {
     content.addArrangedSubview(textLabel("Update Available: v\(latest)", color: .labelColor))
     content.addArrangedSubview(spacer())
     row.toolTip = "A newer version of Magic Switch is available. Opens the release page."
+    row.setAccessibilityLabel("Update available: version \(latest)")
+    row.setAccessibilityHelp(row.toolTip)
     return clickableRow(row, content: content)
   }
 

--- a/Magic Switch/View/MenuBar/DropdownContentView.swift
+++ b/Magic Switch/View/MenuBar/DropdownContentView.swift
@@ -390,7 +390,8 @@ final class DropdownContentView: NSView {
     case .releasing: stateSuffix = ", releasing"
     case .disconnected: stateSuffix = ""
     }
-    let errorSuffix = bluetoothStore.peripheralOperationError[peripheral.id]
+    let errorSuffix =
+      bluetoothStore.peripheralOperationError[peripheral.id]
       .map { ", error: \($0)" } ?? ""
     row.setAccessibilityLabel(peripheral.name + stateSuffix + errorSuffix)
     row.setAccessibilityHelp(row.toolTip)

--- a/Magic Switch/View/MenuBar/DropdownContentView.swift
+++ b/Magic Switch/View/MenuBar/DropdownContentView.swift
@@ -338,7 +338,10 @@ final class DropdownContentView: NSView {
     switch state {
     case .connected:
       if let battery {
-        top.addArrangedSubview(caption("\(battery)%", color: .secondaryLabelColor))
+        // Low battery is the one state worth catching at a glance; 20% is
+        // where macOS fires its own first low-battery warning.
+        let batteryColor: NSColor = battery <= 20 ? .systemOrange : .secondaryLabelColor
+        top.addArrangedSubview(caption("\(battery)%", color: batteryColor))
       }
       top.addArrangedSubview(symbolView("checkmark", color: .controlAccentColor))
     case .connecting:

--- a/Magic Switch/View/Settings/BluetoothPeripheralSettingsView.swift
+++ b/Magic Switch/View/Settings/BluetoothPeripheralSettingsView.swift
@@ -214,6 +214,17 @@ private struct PeripheralRowView: View {
         typeMenu
         Text(peripheral.name)
         Spacer()
+        // Only a peripheral held by this Mac exposes battery in the local
+        // HID registry. Rows re-render on the tab's 2s snapshot timer, so
+        // the reading stays fresh while the tab is visible.
+        if showConnectionStatus, connectionState == .connected,
+          let battery = PeripheralBattery.percent(forAddress: peripheral.id)
+        {
+          Text("\(battery)%")
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .help("Battery level of \(peripheral.name).")
+        }
         if showConnectionStatus {
           connectionButton
           Button(action: { secondaryAction?() }) {

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ On the **Device** tab, find the other Mac under **Connected Devices** and click 
 | --------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | Click the menu-bar icon (either button) | Open the menu |
 | Menu → a Mac | Hand all peripherals between this Mac and that one |
-| Menu → a peripheral | Switch just that one peripheral. Checkmark = currently on this Mac |
+| Menu → a peripheral | Switch just that one peripheral. Checkmark = currently on this Mac, with its battery level |
 | Menu → Settings | Open the Settings window |
 
 The menu-bar icon also signals state: a **warning triangle** means Magic Switch needs attention (not paired, or Bluetooth off/denied) — hover for the reason; **up/down arrows** flash briefly while peripherals are moving between Macs (the dropdown is pictured at the top of this README).


### PR DESCRIPTION
- Battery percentage (read from the HID registry's BatteryPercent, which exists for a peripheral while this Mac holds it) shows beside the checkmark in the dropdown and in the Peripheral tab. The dropdown re-renders on every open so the reading stays current even when no store publisher fires.
- The dropdown's custom rows now exist to VoiceOver: button role, a label carrying name/state/battery/error, tooltips as accessibilityHelp, and enabled-state propagation.