### PR TITLE
feat: explain silent failures when notifications are denied

### DIFF
--- a/Magic Switch/Manager/NotificationManager.swift
+++ b/Magic Switch/Manager/NotificationManager.swift
@@ -42,6 +42,17 @@ final class NotificationManager: NotificationManaging {
     }
   }
 
+  /// Calls back on the main queue with whether the user has explicitly denied
+  /// notifications. Settings → Other uses this to explain that failed
+  /// handoffs and identity warnings would otherwise be silent.
+  static func checkAuthorizationDenied(_ completion: @escaping (Bool) -> Void) {
+    UNUserNotificationCenter.current().getNotificationSettings { settings in
+      DispatchQueue.main.async {
+        completion(settings.authorizationStatus == .denied)
+      }
+    }
+  }
+
   static func requestAuthorization() {
     UNUserNotificationCenter.current().requestAuthorization(
       options: Constants.authorizationOptions

--- a/Magic Switch/View/Settings/OtherSettingsView.swift
+++ b/Magic Switch/View/Settings/OtherSettingsView.swift
@@ -9,6 +9,7 @@ struct OtherSettingsView: View {
   @ObservedObject private var updateChecker = UpdateChecker.shared
   @ObservedObject private var displayMonitor = DisplayMonitor.shared
   @State private var launchAtLogin: Bool = false
+  @State private var notificationsDenied: Bool = false
   @AppStorage(BluetoothPeripheralStore.releaseOnSleepDefaultsKey)
   private var releaseOnSleep: Bool = true
   @AppStorage(BluetoothPeripheralStore.autoReconnectDefaultsKey)
@@ -19,6 +20,19 @@ struct OtherSettingsView: View {
   /// Form content containing setting options
   private var formContent: some View {
     Form {
+      if notificationsDenied {
+        Section {
+          // Failure feedback (cancelled switches, identity mismatches) only
+          // arrives via notifications, so a denied permission means silent
+          // failures — worth flagging where the user can act on it.
+          Label(
+            "Notifications are off, so you won't hear when a switch fails. Enable them for Magic Switch in System Settings → Notifications.",
+            systemImage: "bell.slash"
+          )
+          .font(.callout)
+          .foregroundColor(.secondary)
+        }
+      }
       if #available(macOS 13.0, *) {
         Section(header: Text("General")) {
           Toggle("Launch at Login", isOn: $launchAtLogin)
@@ -222,6 +236,7 @@ struct OtherSettingsView: View {
     refreshLaunchAtLogin()
     displayMonitor.refreshNow()
     updateChecker.checkIfNeeded()
+    NotificationManager.checkAuthorizationDenied { notificationsDenied = $0 }
   }
 
   private func refreshLaunchAtLogin() {


### PR DESCRIPTION
Cancelled switches and identity warnings only surface as notifications, so a denied permission means they vanish. Settings → Other now shows a hint when that's the case, pointing at System Settings → Notifications.