### PR TITLE
style: uniform fixed-width action pills in the Peripherals tab

### DIFF
--- a/Magic Switch/View/Settings/BluetoothPeripheralSettingsView.swift
+++ b/Magic Switch/View/Settings/BluetoothPeripheralSettingsView.swift
@@ -290,11 +290,19 @@ private struct PeripheralRowView: View {
     .help("Set the icon for \(peripheral.name). Choose Automatic to detect it from the device.")
   }
 
+  /// Shared fixed-width label so the pill is the same size in every state
+  /// ("Connect" vs "Release" vs the transient titles) instead of hugging
+  /// each title. Sized to the longest title, "Releasing…", so the pill
+  /// doesn't jump during a handoff; the frame centers the shorter texts.
+  private func actionLabel(_ title: String) -> some View {
+    Text(title).frame(minWidth: 68)
+  }
+
   @ViewBuilder
   private var connectionButton: some View {
     switch connectionState {
     case .connected:
-      Button("Release", action: primaryAction)
+      Button(action: primaryAction) { actionLabel("Release") }
         .disabled(!hasActivePeer)
         .help(
           hasActivePeer
@@ -302,15 +310,15 @@ private struct PeripheralRowView: View {
             : "No peer Mac is currently available to take this peripheral. Releasing is disabled so it isn't left disconnected from both Macs."
         )
     case .connecting:
-      Button("Pairing…", action: {})
+      Button(action: {}) { actionLabel("Pairing…") }
         .disabled(true)
         .help("Pairing in progress…")
     case .releasing:
-      Button("Releasing…", action: {})
+      Button(action: {}) { actionLabel("Releasing…") }
         .disabled(true)
         .help("Handing this peripheral to the other Mac…")
     case .disconnected:
-      Button("Connect", action: primaryAction)
+      Button(action: primaryAction) { actionLabel("Connect") }
         .help(
           "Connect this peripheral to this Mac. If a peer Mac currently holds it, the peer will be asked to release it first."
         )

--- a/Magic Switch/View/Settings/BluetoothPeripheralSettingsView.swift
+++ b/Magic Switch/View/Settings/BluetoothPeripheralSettingsView.swift
@@ -292,10 +292,11 @@ private struct PeripheralRowView: View {
 
   /// Shared fixed-width label so the pill is the same size in every state
   /// ("Connect" vs "Release" vs the transient titles) instead of hugging
-  /// each title. Sized to the longest title, "Releasing…", so the pill
-  /// doesn't jump during a handoff; the frame centers the shorter texts.
+  /// each title. The floor clears the longest title — "Releasing…" measures
+  /// 68.8pt at the 13pt control font — so the pill keeps one width through a
+  /// handoff instead of nudging wider mid-transition; shorter titles centre.
   private func actionLabel(_ title: String) -> some View {
-    Text(title).frame(minWidth: 68)
+    Text(title).frame(minWidth: 72)
   }
 
   @ViewBuilder


### PR DESCRIPTION
The connection button hugged its title, so "Connect" and "Release" pills differed in width and the column edge wandered row to row. All states now share a fixed-width centered label sized to the longest transient title ("Releasing..."), so the pill also doesn't jump during a handoff.