### PR TITLE
fix: publish peripheral battery levels so the Peripherals tab updates live

### DIFF
--- a/Magic Switch/Manager/PeripheralBattery.swift
+++ b/Magic Switch/Manager/PeripheralBattery.swift
@@ -11,7 +11,17 @@ enum PeripheralBattery {
   /// address (IOBluetooth's "aa-bb-cc-dd-ee-ff" format), or nil when the
   /// device isn't connected to this Mac or doesn't report battery.
   static func percent(forAddress address: String) -> Int? {
-    let wanted = normalize(address)
+    levels(forAddresses: [address])[address]
+  }
+
+  /// Battery percentages for the given Bluetooth addresses, keyed by the
+  /// address exactly as passed in. One registry walk regardless of count,
+  /// so a caller polling on a timer (the store's connected-peripherals
+  /// snapshot) reads every device in a single pass.
+  static func levels(forAddresses addresses: [String]) -> [String: Int] {
+    guard !addresses.isEmpty else { return [:] }
+    let wanted = Dictionary(
+      addresses.map { (normalize($0), $0) }, uniquingKeysWith: { first, _ in first })
     var iterator = io_iterator_t()
     // Port 0 = default master port; the named constant for it was renamed in
     // macOS 12 (kIOMasterPortDefault → kIOMainPortDefault) and using either
@@ -19,18 +29,19 @@ enum PeripheralBattery {
     guard
       IOServiceGetMatchingServices(
         0, IOServiceMatching("AppleDeviceManagementHIDEventService"), &iterator) == KERN_SUCCESS
-    else { return nil }
+    else { return [:] }
     defer { IOObjectRelease(iterator) }
 
+    var result: [String: Int] = [:]
     while case let entry = IOIteratorNext(iterator), entry != 0 {
       defer { IOObjectRelease(entry) }
       guard let deviceAddress = property(entry, "DeviceAddress") as? String,
-        normalize(deviceAddress) == wanted,
+        let original = wanted[normalize(deviceAddress)],
         let percent = property(entry, "BatteryPercent") as? Int
       else { continue }
-      return percent
+      result[original] = percent
     }
-    return nil
+    return result
   }
 
   private static func property(_ entry: io_registry_entry_t, _ key: String) -> Any? {

--- a/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
+++ b/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
@@ -157,6 +157,14 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
   /// IOBluetooth disconnect notifications.
   @Published private(set) var connectionStates: [String: PeripheralConnectionState] = [:]
 
+  /// Battery percentage per connected peripheral id, refreshed by each
+  /// `fetchConnectedPeripherals` snapshot (the Peripheral tab polls that on
+  /// a 2s timer). Published state rather than a read-at-render registry
+  /// lookup because a just-connected device surfaces `BatteryPercent` a
+  /// beat *after* its `.connected` state change — a view that reads the
+  /// registry directly during that render never hears about the late value.
+  @Published private(set) var batteryLevels: [String: Int] = [:]
+
   /// One-shot waiters for handoff connect results. Incoming network commands
   /// use these so they can acknowledge "connected" instead of merely
   /// "connect attempt started".
@@ -1191,6 +1199,8 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
           )
         }
 
+        let battery = PeripheralBattery.levels(forAddresses: Array(connectedAddresses))
+
         DispatchQueue.main.async {
           // Snapshot all paired devices; `availablePeripherals` filters out
           // registered ones at read time. Filtering here instead would mean
@@ -1201,6 +1211,7 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
           // (needless re-renders, and it could dismiss an open type picker).
           if self.discoveredPeripherals != paired { self.discoveredPeripherals = paired }
           if self.deviceClasses != classes { self.deviceClasses = classes }
+          if self.batteryLevels != battery { self.batteryLevels = battery }
           // Renaming a device in System Settings → Bluetooth should propagate
           // to our stored list (and thus the dropdown / Settings), so reconcile
           // registered names against the live ones we just read.

--- a/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
+++ b/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
@@ -1199,7 +1199,13 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
           )
         }
 
-        let battery = PeripheralBattery.levels(forAddresses: Array(connectedAddresses))
+        // Registered peripherals only. Every other connected Bluetooth device
+        // (headphones, a game controller) may also publish a level no view
+        // reads, and each one is another value that can change and make the
+        // published dict unequal — i.e. an `objectWillChange` that re-renders
+        // every observer for nothing.
+        let battery = PeripheralBattery.levels(
+          forAddresses: registeredIDs.filter { connectedAddresses.contains($0) })
 
         DispatchQueue.main.async {
           // Snapshot all paired devices; `availablePeripherals` filters out

--- a/Magic Switch/View/Settings/BluetoothPeripheralSettingsView.swift
+++ b/Magic Switch/View/Settings/BluetoothPeripheralSettingsView.swift
@@ -214,11 +214,12 @@ private struct PeripheralRowView: View {
         typeMenu
         Text(peripheral.name)
         Spacer()
-        // Only a peripheral held by this Mac exposes battery in the local
-        // HID registry. Rows re-render on the tab's 2s snapshot timer, so
-        // the reading stays fresh while the tab is visible.
+        // Published store state, not a direct registry read: the level often
+        // appears in the registry a beat after `.connected`, and only a
+        // `@Published` change re-renders this row when that happens. The
+        // tab's 2s snapshot timer keeps it fresh from there.
         if showConnectionStatus, connectionState == .connected,
-          let battery = PeripheralBattery.percent(forAddress: peripheral.id)
+          let battery = store.batteryLevels[peripheral.id]
         {
           Text("\(battery)%")
             .font(.caption)


### PR DESCRIPTION
The Peripherals tab read `BatteryPercent` from the IORegistry inside the row's `body`. That fails twice: the 2s snapshot timer no-ops `@Published` state when nothing changed (so no re-render fires), and at the moment a peripheral connects - the one render that does happen - the registry usually doesn't have `BatteryPercent` yet. Result: no battery shown until a tab switch rebuilt the view.

Battery is now published store state: the existing snapshot reads all connected devices in a single registry walk (new bulk `PeripheralBattery.levels(forAddresses:)`) and publishes a `batteryLevels` dict; the row just reads it. The level appears a tick or two after connect, no tab switch needed.