### PR TITLE
fix: preview the pairing-code group dash as ghost text

### DIFF
--- a/Magic Switch/Manager/PairingStore.swift
+++ b/Magic Switch/Manager/PairingStore.swift
@@ -77,11 +77,7 @@ final class PairingStore: ObservableObject {
   }
 
   /// Returns a display form (`XXXX-XXXX-XXXX`) for a code, grouping into
-  /// fours as it grows ("ABCDE" → "ABCD-E") so a partially typed code picks
-  /// up its dashes live. A complete group gets no trailing dash — the entry
-  /// field reformats on every change, so a trailing dash would reappear the
-  /// moment backspace removed it, and the caret could never move left past
-  /// a group boundary.
+  /// fours as it grows ("ABCDE" → "ABCD-E").
   static func formatCode(_ code: String) -> String {
     let normalized = normalize(code)
     var chunks: [String] = []
@@ -91,6 +87,13 @@ final class PairingStore: ObservableObject {
       rest = rest.dropFirst(4)
     }
     return chunks.joined(separator: "-")
+  }
+
+  /// True when `code` ends exactly at a complete, non-final 4-character
+  /// group — the position where the display format expects a dash next.
+  static func endsAtGroupBoundary(_ code: String) -> Bool {
+    let count = normalize(code).count
+    return count > 0 && count < codeLength && count % 4 == 0
   }
 
   /// Normalizes free-form user input: uppercase, then apply Crockford's

--- a/Magic Switch/View/Settings/PairingSettingsView.swift
+++ b/Magic Switch/View/Settings/PairingSettingsView.swift
@@ -253,18 +253,54 @@ private struct EnterCodeSheet: View {
   @State private var errorMessage: String?
   @State private var isPairing = false
 
+  private static let codeFont = Font.system(.title2, design: .monospaced)
+
+  /// Leading inset of the text inside a rounded-border NSTextField, used to
+  /// line the ghost-dash overlay up with the field's own glyphs. Measured
+  /// against an offscreen render of this exact field at 2× — together with
+  /// the -1.5pt baseline offset it puts the ghost dash pixel-identical to
+  /// where the committed dash lands.
+  private static let fieldTextInset: CGFloat = 6.5
+
+  /// The upcoming group separator, drawn grayed at the caret position when
+  /// a group has just been completed. It's a preview, not field text: typing
+  /// "-" commits it, typing the next code character commits both.
+  private var showsGhostDash: Bool {
+    PairingStore.endsAtGroupBoundary(input) && !input.hasSuffix("-")
+  }
+
+  @ViewBuilder
+  private var ghostDash: some View {
+    if showsGhostDash {
+      (Text(input).foregroundColor(.clear) + Text("-").foregroundColor(.secondary))
+        .font(Self.codeFont)
+        .padding(.leading, Self.fieldTextInset)
+        .offset(y: -1.5)
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+  }
+
   var body: some View {
     VStack(spacing: 20) {
       Text("Enter Pairing Code")
         .font(.headline)
       TextField("XXXX-XXXX-XXXX", text: $input)
         .textFieldStyle(RoundedBorderTextFieldStyle())
-        .font(.system(.title2, design: .monospaced))
+        .font(Self.codeFont)
         .disabled(isPairing)
+        .overlay(ghostDash, alignment: .leading)
         .onChange(of: input) { newValue in
           let normalized = PairingStore.normalize(newValue)
           let limited = String(normalized.prefix(PairingStore.codeLength))
-          let formatted = PairingStore.formatCode(limited)
+          var formatted = PairingStore.formatCode(limited)
+          // A trailing dash at a complete group boundary is kept, whether
+          // typed or backspaced-up-against; stray dashes anywhere else are
+          // dropped by the reformat. The auto-dash itself is never inserted
+          // here — it lives in the ghost overlay until committed.
+          if newValue.hasSuffix("-"), PairingStore.endsAtGroupBoundary(limited) {
+            formatted += "-"
+          }
           if formatted != newValue {
             input = formatted
           }


### PR DESCRIPTION
The Enter Pairing Code field reformatted on every keystroke and silently deleted any dash the user typed — even though the Generate Code sheet displays the code as `XXXX-XXXX-XXXX`, so typing it verbatim is the natural thing to do. The auto-dash also only appeared together with the fifth character.

The upcoming separator is now drawn as a **grayed ghost dash** at the caret as soon as a group completes: typing `-` commits it, typing the next code character commits both, and backspace walks back through the boundary one character at a time. The dash is never force-inserted, so there's no caret trap and no previous-value bookkeeping.

The overlay inset/baseline constants were measured against an offscreen render of the exact field (2×) so the ghost lands pixel-identical to a committed dash. Verified with a simulation of the onChange loop covering typing, manual dashes, backspace over dashes, paste (formatted/raw/lowercase/overflow), and delete-all — plus a clean build.