### PR TITLE
style: two points of headroom on the peripheral action pill floor

### DIFF
--- a/Magic Switch/View/Settings/BluetoothPeripheralSettingsView.swift
+++ b/Magic Switch/View/Settings/BluetoothPeripheralSettingsView.swift
@@ -293,13 +293,16 @@ private struct PeripheralRowView: View {
 
   /// Shared fixed-width label so the pill is the same size across its
   /// resting states instead of hugging each title. The floor clears
-  /// "Connect" (51.2pt) and "Pairing…" (51.9pt at the 13pt control font),
-  /// so rows align and a Connect ↔ Release flip doesn't nudge; sizing the
-  /// floor to the rarely-seen "Releasing…" (68.8pt) instead left the two
-  /// resting titles swimming in dead space, and the brief growth during a
-  /// release reads as activity rather than jitter.
+  /// "Connect" (51.2pt) and "Pairing…" (51.9pt at the 13pt control font) —
+  /// the 54 buys the latter a couple of points of headroom against
+  /// font-metric drift, where a 52 floor would sit 0.1pt from a
+  /// connecting-state nudge — so rows align and a Connect ↔ Release flip
+  /// doesn't nudge; sizing the floor to the rarely-seen "Releasing…"
+  /// (68.8pt) instead left the two resting titles swimming in dead space,
+  /// and the brief growth during a release reads as activity rather than
+  /// jitter.
   private func actionLabel(_ title: String) -> some View {
-    Text(title).frame(minWidth: 52)
+    Text(title).frame(minWidth: 54)
   }
 
   @ViewBuilder


### PR DESCRIPTION
Follow-up from a post-merge audit of #80 (all four pill titles measured at the 13pt control font: Connect 51.17pt, Release 47.32pt, Pairing… 51.91pt, Releasing… 68.84pt).

The 52pt floor clears "Pairing…" by 0.09pt — a rounding error away from a connecting-state row nudging out of alignment if SF Pro metrics drift in a macOS update. 54 is visually identical for every resting title and turns the knife-edge into real headroom. Comment updated with the reasoning.