### PR TITLE
fix: hop outgoing-queue completions to main before touching transfer state

### DIFF
--- a/Magic Switch/AppDelegate/AppDelegate.swift
+++ b/Magic Switch/AppDelegate/AppDelegate.swift
@@ -544,18 +544,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
       // fail to hand peripherals over, leaving them paired nowhere.
       beginTransfer(.sending)
       networkStore.executeCommand(.ping, on: device) { [weak self] preflight in
-        guard let self = self else { return }
-        switch preflight {
-        case .failure(let err):
-          self.endTransfer()
-          NotificationManager.showNotification(
-            title: "Switch Cancelled",
-            body:
-              "Couldn't reach the other Mac (\(err.userMessage)) — peripherals stay on this Mac.",
-            identifier: "switch-preflight-failed"
-          )
-        case .success:
-          self.performHandoffToPeer(device: device)
+        // Fires on the outgoing-connection queue; hop to main before
+        // `endTransfer` touches the status-bar button / transfer state, and
+        // before `performHandoffToPeer` reads the published peripherals.
+        DispatchQueue.main.async {
+          guard let self = self else { return }
+          switch preflight {
+          case .failure(let err):
+            self.endTransfer()
+            NotificationManager.showNotification(
+              title: "Switch Cancelled",
+              body:
+                "Couldn't reach the other Mac (\(err.userMessage)) — peripherals stay on this Mac.",
+              identifier: "switch-preflight-failed"
+            )
+          case .success:
+            self.performHandoffToPeer(device: device)
+          }
         }
       }
     case .allDisconnected:
@@ -728,24 +733,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         return
       }
       self.networkStore.executeCommand(.connectAll, on: device) { [weak self] result in
-        guard let self = self else { return }
-        if case .failure(let err) = result {
-          // Rollback: peer didn't take the peripherals, so re-pair them
-          // locally. Without this the user is left with peripherals paired
-          // nowhere. `connectPeripheral` flips each row to `.connecting`,
-          // which clears the "Releasing…" state on its own.
-          self.bluetoothStore.peripherals.forEach { peripheral in
-            self.bluetoothStore.connectPeripheral(peripheral)
+        // The completion fires on the outgoing-connection queue (see
+        // `takeAllPeripherals`); hop to main before `endTransfer` touches
+        // the status-bar button and the transfer/latch state the settle
+        // observer reads on main.
+        DispatchQueue.main.async {
+          guard let self = self else { return }
+          if case .failure(let err) = result {
+            // Rollback: peer didn't take the peripherals, so re-pair them
+            // locally. Without this the user is left with peripherals paired
+            // nowhere. `connectPeripheral` flips each row to `.connecting`,
+            // which clears the "Releasing…" state on its own.
+            self.bluetoothStore.peripherals.forEach { peripheral in
+              self.bluetoothStore.connectPeripheral(peripheral)
+            }
+            self.endTransfer()
+            NotificationManager.showNotification(
+              title: "Switch Failed",
+              body: "\(err.userMessage) Peripherals reconnected to this Mac.",
+              identifier: "switch-connect-failed"
+            )
+          } else {
+            self.bluetoothStore.finishFullSetRelease(success: true)
+            self.endTransfer()
           }
-          self.endTransfer()
-          NotificationManager.showNotification(
-            title: "Switch Failed",
-            body: "\(err.userMessage) Peripherals reconnected to this Mac.",
-            identifier: "switch-connect-failed"
-          )
-        } else {
-          self.bluetoothStore.finishFullSetRelease(success: true)
-          self.endTransfer()
         }
       }
     }


### PR DESCRIPTION
Follow-up from a post-merge audit of #82 (adversarial review of the merged diff against the codebase).

`executeCommand` completions fire on the outgoing-connection queue, but two of them touched main-affine state:

* `performHandoffToPeer`'s `.connectAll` completion called `endTransfer()` — which touches `statusItem.button` and the transfer/latch state the settle observer reads on main — plus `finishFullSetRelease` (reads the published peripherals array) off-main.
* `handleSwitchAction`'s `.ping` preflight did the same in its failure arm, and its success arm entered `performHandoffToPeer` off-main.

Both completions are now wrapped in a main hop, mirroring what `takeAllPeripherals` already did. Pre-existing rather than introduced by #82, but #82's held-transfer latch (`transferLatchedAt`, the settle observer) made these variables genuinely main-only, so the off-main writes graduated from AppKit-hygiene violation to a real data race.

The audit otherwise confirmed #82's mechanism on every sequencing path: all latch paths flip their rows `.connecting`/`.releasing` synchronously in the same main-queue tick as the latch, `.receive(on: main)` defers the willSet-time sink past the write, every explicit `beginTransfer` has a guaranteed end, and the bell-flash interplay is safe in both directions.

Builds clean; verified by an independent adversarial pass over the final diff.