### PR TITLE
fix: let the identity-mismatch self-heal actually fire, pinned to the proved key

### DIFF
--- a/Magic Switch/Manager/IncomingConnection.swift
+++ b/Magic Switch/Manager/IncomingConnection.swift
@@ -126,14 +126,18 @@ final class IncomingConnection {
       switch result {
       case .success:
         self.authenticated = true
-        // The peer has proved possession of this Mac's current pairing key —
-        // strictly stronger evidence than the fingerprint it advertises over
-        // cleartext mDNS. If a registered device is stuck behind an Identity
-        // Mismatch that pends exactly the current key (both Macs re-paired),
-        // resolve it now instead of honoring commands while the Macs tab
-        // claims switching is paused.
+        // The peer has proved possession of the pairing key this handshake
+        // ran with — strictly stronger evidence than the fingerprint it
+        // advertises over cleartext mDNS. If a registered device is stuck
+        // behind an Identity Mismatch that pends exactly the current key
+        // (both Macs re-paired), resolve it now instead of honoring commands
+        // while the Macs tab claims switching is paused. Fingerprint the
+        // accept-time PSK snapshot, not the live key, so a re-pair racing
+        // this hop can't count a stale proof against the new key.
+        let provedFingerprint = PairingStore.fingerprint(forKey: psk)
         DispatchQueue.main.async {
-          NetworkDeviceStore.shared.resolvePendingFingerprintProvedByHandshake()
+          NetworkDeviceStore.shared.resolvePendingFingerprint(
+            provedByHandshake: provedFingerprint)
         }
         self.resetIdleTimer()
         self.readNext()

--- a/Magic Switch/Manager/OutgoingConnection.swift
+++ b/Magic Switch/Manager/OutgoingConnection.swift
@@ -200,6 +200,19 @@ final class OutgoingConnection {
           case .success:
             self.connectTimer?.cancel()
             self.connectTimer = nil
+            // The handshake is mutual — the responder proved possession of
+            // this key before our `.success` fired — so feed the
+            // identity-mismatch self-heal from the initiating side too:
+            // the reachability poll's own ping is what creates this proof
+            // for a parked-but-current peer, and without this arm the
+            // initiator would stay parked until the peer happened to dial
+            // back. Fingerprint the PSK snapshot this channel actually ran
+            // with (see `resolvePendingFingerprint`).
+            let provedFingerprint = PairingStore.fingerprint(forKey: psk)
+            DispatchQueue.main.async {
+              NetworkDeviceStore.shared.resolvePendingFingerprint(
+                provedByHandshake: provedFingerprint)
+            }
             self.startBodyTimer(completion: completion)
             body(channel) { ok in
               self.finish(

--- a/Magic Switch/Manager/PairingStore.swift
+++ b/Magic Switch/Manager/PairingStore.swift
@@ -226,6 +226,13 @@ final class PairingStore: ObservableObject {
     return prefix.map { String(format: "%02X", $0) }.joined()
   }
 
+  /// Same, over a key already wrapped as `SymmetricKey` — used to fingerprint
+  /// the exact PSK snapshot a secure channel handshaked with, which can lag
+  /// `fingerprint` if the user re-pairs while a connection is in flight.
+  static func fingerprint(forKey key: SymmetricKey) -> String {
+    key.withUnsafeBytes { fingerprint(forKey: Data($0)) }
+  }
+
   // MARK: - Private Methods
 
   private func refreshState() {

--- a/Magic Switch/Model/Store/NetworkDeviceStore.swift
+++ b/Magic Switch/Model/Store/NetworkDeviceStore.swift
@@ -335,23 +335,35 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
     saveNetworkDevices()
   }
 
-  /// A peer just completed the secure-channel handshake, proving it holds
-  /// this Mac's *current* pairing key. If a registered device is parked
-  /// behind an Identity Mismatch whose pending fingerprint is exactly the
-  /// current key's fingerprint, the proof supersedes the warning: the
-  /// handshake demonstrates the very thing Trust would have taken on faith
-  /// from a cleartext TXT record. That is the "both Macs were re-paired"
-  /// state — the pin predates the re-pair while both sides already share
-  /// the new key — and without this the warning sticks (and outgoing
-  /// switching stays paused) until the user manually Trusts on each Mac,
-  /// even though incoming commands from the peer were honored the whole
-  /// time, making the warning read like an enforcement it never was.
+  /// A peer just completed a secure-channel handshake, proving it holds the
+  /// key whose fingerprint is `provedFingerprint` — the exact PSK snapshot
+  /// that channel ran with, not whatever is current by the time this hop
+  /// lands, so a handshake that raced a re-pair can't clear a warning about
+  /// a key the peer never proved. If a registered device is parked behind
+  /// an Identity Mismatch whose pending fingerprint is exactly the current
+  /// key's fingerprint (and the proof is for that same key), the proof
+  /// supersedes the warning: the handshake demonstrates the very thing
+  /// Trust would have taken on faith from a cleartext TXT record. That is
+  /// the "both Macs were re-paired" state — the pin predates the re-pair
+  /// while both sides already share the new key — and without this the
+  /// warning sticks (and outgoing switching stays paused) until the user
+  /// manually Trusts on each Mac, even though incoming commands from the
+  /// peer were honored the whole time, making the warning read like an
+  /// enforcement it never was.
   ///
   /// Deliberately narrow: a pending fingerprint that matches anything
   /// *other* than the current key stays parked for the user to judge — the
   /// handshake says nothing about a key this Mac doesn't hold.
-  func resolvePendingFingerprintProvedByHandshake() {
-    guard let currentFingerprint = PairingStore.shared.fingerprint else { return }
+  ///
+  /// Called from both connection directions — the responder side on an
+  /// incoming handshake, the initiator side on an outgoing one (the
+  /// handshake is mutual, each side verifies the other's transcript MAC
+  /// before reporting success) — so whichever Mac's reachability poll fires
+  /// first heals both ends of a symmetric mutual-re-pair park.
+  func resolvePendingFingerprint(provedByHandshake provedFingerprint: String) {
+    guard let currentFingerprint = PairingStore.shared.fingerprint,
+      provedFingerprint == currentFingerprint
+    else { return }
     var changed = false
     for index in networkDevices.indices
     where networkDevices[index].pendingFingerprint == currentFingerprint {
@@ -363,6 +375,19 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
       // over a live connection from the peer.
       deviceReachability[networkDevices[index].id] = true
       changed = true
+      // Mirror the rename self-heal's announcement so the warning doesn't
+      // just silently vanish on a user who saw it appear. Reusing the
+      // mismatch identifier replaces the stale "choose Trust" alert in
+      // Notification Center instead of stacking next to it.
+      print(
+        "Resolved identity mismatch for \"\(networkDevices[index].name)\" (peer proved the current pairing key)"
+      )
+      NotificationManager.showNotification(
+        title: "Identity Mismatch Resolved",
+        body:
+          "\(networkDevices[index].name) proved it holds this Mac's current pairing key, so the identity warning was cleared and switching resumed. If you didn't re-pair both Macs yourself, re-pair them with a fresh code.",
+        identifier: "identity-mismatch-\(networkDevices[index].id)"
+      )
     }
     if changed {
       saveNetworkDevices()
@@ -413,7 +438,13 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
     // unclaimed for ~a minute. Guard `isPaired` so the probe can't book a
     // spurious `.notPaired` failure into the streak.
     if !isActive, PairingStore.shared.isPaired,
-      let device = networkDevices.first(where: { $0.id == id && $0.pendingFingerprint == nil })
+      let device = networkDevices.first(where: {
+        // Same probe-eligibility rule as `pollReachability`, including the
+        // parked-but-current self-heal exception.
+        $0.id == id
+          && ($0.pendingFingerprint == nil
+            || $0.pendingFingerprint == PairingStore.shared.fingerprint)
+      })
     {
       probeReachability(of: device)
     }
@@ -466,10 +497,19 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
   private func pollReachability() {
     // `.ping` rides the secure channel, so it's meaningless unpaired — skip
     // (leaving the pessimistic default) rather than spam `.notPaired` failures.
-    // Skip mismatched peers too: a `.ping` with our old key would just auth-fail
-    // and feed the peer's inbound rate limiter.
+    // Skip mismatched peers too — a `.ping` against a peer whose key genuinely
+    // differs would just auth-fail and feed its inbound rate limiter — EXCEPT
+    // when the pending fingerprint is exactly our current key's: then the ping
+    // authenticates (we hold the very key being advertised), and its handshake
+    // is what lets both sides self-heal the stale mismatch a mutual re-pair
+    // leaves behind (see `resolvePendingFingerprint(provedByHandshake:)`).
+    // Without the exception, two Macs parked symmetrically would never
+    // initiate a connection in either direction and the "proves it over the
+    // secure channel" resolution could never actually fire.
     guard PairingStore.shared.isPaired else { return }
-    for device in networkDevices where device.pendingFingerprint == nil {
+    let currentFingerprint = PairingStore.shared.fingerprint
+    for device in networkDevices
+    where device.pendingFingerprint == nil || device.pendingFingerprint == currentFingerprint {
       probeReachability(of: device)
     }
   }
@@ -531,10 +571,14 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
     DispatchQueue.main.asyncAfter(deadline: .now() + Self.fastRecheckDelay) { [weak self] in
       guard let self = self else { return }
       self.pendingFastRecheck.remove(device.id)
-      // Re-probe only if it's still a registered, paired, non-mismatched peer.
+      // Re-probe only if it's still a registered, paired peer that the poll
+      // itself would probe (not mismatched — or pending exactly our current
+      // key, the self-heal exception in `pollReachability`).
       guard PairingStore.shared.isPaired,
         let current = self.networkDevices.first(where: {
-          $0.id == device.id && $0.pendingFingerprint == nil
+          $0.id == device.id
+            && ($0.pendingFingerprint == nil
+              || $0.pendingFingerprint == PairingStore.shared.fingerprint)
         })
       else { return }
       self.probeReachability(of: current)


### PR DESCRIPTION
Follow-up from a post-merge audit of #83 (security-focused adversarial review of the merged diff against the codebase — the core claim holds: `.success` fires only after decrypting and constant-time-verifying the peer's transcript MAC over both fresh nonces, so the resolver is unreachable without live proof of the PSK).

**Make the self-heal actually fire.** Resolution triggered only on an *incoming* handshake, but the headline scenario — both Macs re-paired — parks BOTH sides, and every outgoing initiator (reachability poll, withdraw probe, fast recheck, sleep push, wake reclaims, the watcher, the menu rows, Ping/Sync buttons) skips parked rows. In the symmetric case neither side ever dialed, no handshake happened, and the warning stuck exactly as pre-#83. Now:

* The reachability poll (and the Bonjour-withdraw fast probe) also probe a parked peer whose pending fingerprint is exactly **our current key's** — that ping authenticates, since we hold the very key being advertised, while genuinely-different keys stay skipped so the peer's inbound rate limiter is never fed.
* The **outgoing** handshake success arm feeds the resolver too (the handshake is mutual — the responder proved the key before the client's `.success`), so one ~30s poll cycle heals both ends without user action, making the Macs-tab tooltip's promise true.

**Prove the key that was actually proved.** The resolver now takes the fingerprint of the PSK snapshot the channel handshaked with and requires it to equal the current key — closing the TOCTOU where a handshake started just before a re-pair could clear a warning about a key the peer never proved.

**Don't vanish silently.** Resolution logs and posts "Identity Mismatch Resolved", reusing the onset alert's identifier so it *replaces* the stale "choose Trust" banner in Notification Center instead of stacking next to it (mirrors the rename-migration precedent).

Builds clean; verified by an independent adversarial pass over the final diff.