### PR TITLE
feat: Bonjour-less peer discovery — INTRODUCE exchange, stable port, Add by Address, advertising diagnostics

### DIFF
--- a/Magic Switch.xcodeproj/project.pbxproj
+++ b/Magic Switch.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		076AB21F2CE9D690004D45F0 /* ServicePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076AB1FE2CE9D690004D45F0 /* ServicePublisher.swift */; };
 		0A00003000000000000000B7 /* SleepMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00003000000000000000A7 /* SleepMonitor.swift */; };
 		0A00007000000000000000BC /* PeripheralBattery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00007000000000000000AC /* PeripheralBattery.swift */; };
+		0A00008000000000000000BD /* AdvertisingDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00008000000000000000AD /* AdvertisingDiagnostics.swift */; };
 		0A00004000000000000000B8 /* DisplayMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00004000000000000000A8 /* DisplayMonitor.swift */; };
 		0A00001000000000000000B1 /* SecureChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00001000000000000000A1 /* SecureChannel.swift */; };
 		0A00001000000000000000B2 /* PairingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00001000000000000000A2 /* PairingStore.swift */; };
@@ -52,6 +53,7 @@
 		076AB1FE2CE9D690004D45F0 /* ServicePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServicePublisher.swift; sourceTree = "<group>"; };
 		0A00003000000000000000A7 /* SleepMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepMonitor.swift; sourceTree = "<group>"; };
 		0A00007000000000000000AC /* PeripheralBattery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeripheralBattery.swift; sourceTree = "<group>"; };
+		0A00008000000000000000AD /* AdvertisingDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvertisingDiagnostics.swift; sourceTree = "<group>"; };
 		0A00004000000000000000A8 /* DisplayMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayMonitor.swift; sourceTree = "<group>"; };
 		0A00001000000000000000A1 /* SecureChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureChannel.swift; sourceTree = "<group>"; };
 		0A00001000000000000000A2 /* PairingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingStore.swift; sourceTree = "<group>"; };
@@ -116,6 +118,7 @@
 				0A00003000000000000000A7 /* SleepMonitor.swift */,
 				0A00004000000000000000A8 /* DisplayMonitor.swift */,
 				0A00007000000000000000AC /* PeripheralBattery.swift */,
+				0A00008000000000000000AD /* AdvertisingDiagnostics.swift */,
 				0A00001000000000000000A1 /* SecureChannel.swift */,
 				0A00001000000000000000A2 /* PairingStore.swift */,
 				0A00001000000000000000A3 /* IncomingConnection.swift */,
@@ -304,6 +307,7 @@
 				076AB2182CE9D690004D45F0 /* Magic_SwitchApp.swift in Sources */,
 				076AB2192CE9D690004D45F0 /* IOBluetoothDevice+Extension.swift in Sources */,
 				0A00007000000000000000BC /* PeripheralBattery.swift in Sources */,
+				0A00008000000000000000BD /* AdvertisingDiagnostics.swift in Sources */,
 				076AB21A2CE9D690004D45F0 /* NetworkDevice+HealthCheck.swift in Sources */,
 				076AB21B2CE9D690004D45F0 /* BluetoothManager.swift in Sources */,
 				076AB21D2CE9D690004D45F0 /* NotificationManager.swift in Sources */,

--- a/Magic Switch.xcodeproj/project.pbxproj
+++ b/Magic Switch.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		0A00003000000000000000B7 /* SleepMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00003000000000000000A7 /* SleepMonitor.swift */; };
 		0A00007000000000000000BC /* PeripheralBattery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00007000000000000000AC /* PeripheralBattery.swift */; };
 		0A00008000000000000000BD /* AdvertisingDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00008000000000000000AD /* AdvertisingDiagnostics.swift */; };
+		0A00009000000000000000BE /* DialbackAddresses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00009000000000000000AE /* DialbackAddresses.swift */; };
 		0A00004000000000000000B8 /* DisplayMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00004000000000000000A8 /* DisplayMonitor.swift */; };
 		0A00001000000000000000B1 /* SecureChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00001000000000000000A1 /* SecureChannel.swift */; };
 		0A00001000000000000000B2 /* PairingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A00001000000000000000A2 /* PairingStore.swift */; };
@@ -54,6 +55,7 @@
 		0A00003000000000000000A7 /* SleepMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepMonitor.swift; sourceTree = "<group>"; };
 		0A00007000000000000000AC /* PeripheralBattery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeripheralBattery.swift; sourceTree = "<group>"; };
 		0A00008000000000000000AD /* AdvertisingDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvertisingDiagnostics.swift; sourceTree = "<group>"; };
+		0A00009000000000000000AE /* DialbackAddresses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialbackAddresses.swift; sourceTree = "<group>"; };
 		0A00004000000000000000A8 /* DisplayMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayMonitor.swift; sourceTree = "<group>"; };
 		0A00001000000000000000A1 /* SecureChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureChannel.swift; sourceTree = "<group>"; };
 		0A00001000000000000000A2 /* PairingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingStore.swift; sourceTree = "<group>"; };
@@ -119,6 +121,7 @@
 				0A00004000000000000000A8 /* DisplayMonitor.swift */,
 				0A00007000000000000000AC /* PeripheralBattery.swift */,
 				0A00008000000000000000AD /* AdvertisingDiagnostics.swift */,
+				0A00009000000000000000AE /* DialbackAddresses.swift */,
 				0A00001000000000000000A1 /* SecureChannel.swift */,
 				0A00001000000000000000A2 /* PairingStore.swift */,
 				0A00001000000000000000A3 /* IncomingConnection.swift */,
@@ -308,6 +311,7 @@
 				076AB2192CE9D690004D45F0 /* IOBluetoothDevice+Extension.swift in Sources */,
 				0A00007000000000000000BC /* PeripheralBattery.swift in Sources */,
 				0A00008000000000000000BD /* AdvertisingDiagnostics.swift in Sources */,
+				0A00009000000000000000BE /* DialbackAddresses.swift in Sources */,
 				076AB21A2CE9D690004D45F0 /* NetworkDevice+HealthCheck.swift in Sources */,
 				076AB21B2CE9D690004D45F0 /* BluetoothManager.swift in Sources */,
 				076AB21D2CE9D690004D45F0 /* NotificationManager.swift in Sources */,

--- a/Magic Switch/Manager/AdvertisingDiagnostics.swift
+++ b/Magic Switch/Manager/AdvertisingDiagnostics.swift
@@ -32,6 +32,12 @@ final class AdvertisingDiagnostics: ObservableObject {
   }
 
   func servicePublishFailed() {
+    // Kill any in-flight self-check: its settle timer would otherwise read
+    // pre-failure browse results and clear the warning posted here.
+    queue.async {
+      self.checkGeneration += 1
+      self.stopBrowse()
+    }
     reportPublish(Self.notAdvertisingMessage())
   }
 

--- a/Magic Switch/Manager/AdvertisingDiagnostics.swift
+++ b/Magic Switch/Manager/AdvertisingDiagnostics.swift
@@ -1,0 +1,108 @@
+import Foundation
+import dnssd
+
+/// Advisory discovery health, surfaced in the Macs tab. The failure it
+/// exists for is otherwise silent: mDNSResponder accepts a registration but
+/// never puts it on the wire (MDM's `NoMulticastAdvertisements`), so the
+/// peer simply never sees this Mac. `NetServiceBrowser` hides interface
+/// indexes, so the self-check browses via the dnssd C API: an own instance
+/// seen only on the local-only pseudo-interface is not on the air.
+final class AdvertisingDiagnostics: ObservableObject {
+  static let shared = AdvertisingDiagnostics()
+
+  @Published private(set) var warning: String?
+
+  private static let settleTime: TimeInterval = 10
+  private let queue = DispatchQueue(label: "com.magicswitch.diagnostics")
+  private var browseRef: DNSServiceRef?
+  private var ownName: String?
+  private var seenOnWire = false
+  /// Ties each settle timer to its own browse, so a republish restarting the
+  /// check can't have the previous timer report (and stop) the new one.
+  private var checkGeneration = 0
+
+  private init() {}
+
+  func servicePublished(name: String) {
+    queue.async { self.startSelfCheck(name: name) }
+  }
+
+  func servicePublishFailed() {
+    report(Self.notAdvertisingMessage())
+  }
+
+  func serviceSearchFailed() {
+    report(
+      "This Mac couldn't search the network for other Macs. Use Add by Address if your other Mac doesn't appear."
+    )
+  }
+
+  private func startSelfCheck(name: String) {
+    stopBrowse()
+    ownName = name
+    seenOnWire = false
+    var ref: DNSServiceRef?
+    let context = Unmanaged.passUnretained(self).toOpaque()
+    let err = DNSServiceBrowse(
+      &ref, 0, 0, "_magicswitch._tcp", "local.",
+      { _, _, interfaceIndex, errorCode, serviceName, _, _, context in
+        guard errorCode == kDNSServiceErr_NoError,
+          let context = context, let serviceName = serviceName
+        else { return }
+        Unmanaged<AdvertisingDiagnostics>.fromOpaque(context).takeUnretainedValue()
+          .handleBrowseResult(name: String(cString: serviceName), interfaceIndex: interfaceIndex)
+      }, context)
+    guard err == kDNSServiceErr_NoError, let browse = ref else { return }
+    DNSServiceSetDispatchQueue(browse, queue)
+    browseRef = browse
+    checkGeneration += 1
+    let generation = checkGeneration
+    queue.asyncAfter(deadline: .now() + Self.settleTime) { [weak self] in
+      self?.finishSelfCheck(generation: generation)
+    }
+  }
+
+  private func handleBrowseResult(name: String, interfaceIndex: UInt32) {
+    guard name == ownName else { return }
+    if interfaceIndex != kDNSServiceInterfaceIndexLocalOnly {
+      seenOnWire = true
+    }
+  }
+
+  private func finishSelfCheck(generation: Int) {
+    guard generation == checkGeneration else { return }
+    stopBrowse()
+    report(seenOnWire ? nil : Self.notAdvertisingMessage())
+  }
+
+  private func stopBrowse() {
+    if let ref = browseRef {
+      DNSServiceRefDeallocate(ref)
+      browseRef = nil
+    }
+  }
+
+  private func report(_ message: String?) {
+    DispatchQueue.main.async { self.warning = message }
+  }
+
+  private static func notAdvertisingMessage() -> String {
+    let cause =
+      advertisingDisabledByPolicy()
+      ? "Bonjour advertising is disabled by policy on this Mac (NoMulticastAdvertisements)"
+      : "This Mac's Bonjour advertisements aren't reaching the network"
+    return
+      "\(cause), so your other Mac can't discover it by itself. An already-added Mac still reaches it automatically; otherwise use Add by Address on the other Mac."
+  }
+
+  /// Best-effort: the sandbox usually denies this read, and the generic
+  /// wording stands.
+  private static func advertisingDisabledByPolicy() -> Bool {
+    let value = CFPreferencesCopyValue(
+      "NoMulticastAdvertisements" as CFString,
+      "com.apple.mDNSResponder" as CFString,
+      kCFPreferencesAnyUser,
+      kCFPreferencesAnyHost)
+    return (value as? NSNumber)?.boolValue ?? false
+  }
+}

--- a/Magic Switch/Manager/AdvertisingDiagnostics.swift
+++ b/Magic Switch/Manager/AdvertisingDiagnostics.swift
@@ -10,7 +10,11 @@ import dnssd
 final class AdvertisingDiagnostics: ObservableObject {
   static let shared = AdvertisingDiagnostics()
 
-  @Published private(set) var warning: String?
+  /// Publish health ("your other Mac can't see this one") and search health
+  /// ("this Mac can't see others") fail independently — separate slots so
+  /// the self-check's verdict can't wipe a search advisory, or vice versa.
+  @Published private(set) var publishWarning: String?
+  @Published private(set) var searchWarning: String?
 
   private static let settleTime: TimeInterval = 10
   private let queue = DispatchQueue(label: "com.magicswitch.diagnostics")
@@ -28,11 +32,15 @@ final class AdvertisingDiagnostics: ObservableObject {
   }
 
   func servicePublishFailed() {
-    report(Self.notAdvertisingMessage())
+    reportPublish(Self.notAdvertisingMessage())
+  }
+
+  func serviceSearchStarted() {
+    reportSearch(nil)
   }
 
   func serviceSearchFailed() {
-    report(
+    reportSearch(
       "This Mac couldn't search the network for other Macs. Use Add by Address if your other Mac doesn't appear."
     )
   }
@@ -72,7 +80,7 @@ final class AdvertisingDiagnostics: ObservableObject {
   private func finishSelfCheck(generation: Int) {
     guard generation == checkGeneration else { return }
     stopBrowse()
-    report(seenOnWire ? nil : Self.notAdvertisingMessage())
+    reportPublish(seenOnWire ? nil : Self.notAdvertisingMessage())
   }
 
   private func stopBrowse() {
@@ -82,8 +90,12 @@ final class AdvertisingDiagnostics: ObservableObject {
     }
   }
 
-  private func report(_ message: String?) {
-    DispatchQueue.main.async { self.warning = message }
+  private func reportPublish(_ message: String?) {
+    DispatchQueue.main.async { self.publishWarning = message }
+  }
+
+  private func reportSearch(_ message: String?) {
+    DispatchQueue.main.async { self.searchWarning = message }
   }
 
   private static func notAdvertisingMessage() -> String {

--- a/Magic Switch/Manager/DialbackAddresses.swift
+++ b/Magic Switch/Manager/DialbackAddresses.swift
@@ -38,11 +38,12 @@ final class DialbackAddresses: ObservableObject {
   }
 
   /// One line for UI captions — "192.168.1.23 (Wi-Fi)", possibly
-  /// "… or 10.0.0.5 (Ethernet)". The proven address wins outright while it
-  /// is still assigned to an interface; otherwise up to two labeled
-  /// candidates in the system's own preference order. nil when nothing
-  /// credible is known. Main-only.
-  func displayList() -> String? {
+  /// "… or 10.0.0.5 (Ethernet)" — plus whether a handshake proved it, so
+  /// the UI can qualify its confidence. The proven address wins outright
+  /// while it is still assigned to an interface; otherwise up to two
+  /// labeled candidates in the system's own preference order. nil when
+  /// nothing credible is known. Main-only.
+  func display() -> (addresses: String, proven: Bool)? {
     let addresses = Self.interfaceAddresses()
     let viable = currentPath?.availableInterfaces ?? []
     let labels = Dictionary(
@@ -51,7 +52,7 @@ final class DialbackAddresses: ObservableObject {
     if let proven = provenHost,
       let owner = addresses.first(where: { $0.host == proven })?.interface
     {
-      return Self.entry(proven, labels[owner])
+      return (Self.entry(proven, labels[owner]), proven: true)
     }
     // `availableInterfaces` repeats an interface (once per address family).
     var seenNames: Set<String> = []
@@ -67,7 +68,7 @@ final class DialbackAddresses: ObservableObject {
       entries = addresses.filter { $0.isIPv4 }.map { Self.entry($0.host, nil) }
     }
     guard !entries.isEmpty else { return nil }
-    return entries.prefix(2).joined(separator: " or ")
+    return (entries.prefix(2).joined(separator: " or "), proven: false)
   }
 
   /// Dialable host string of an endpoint — unlike `RateLimiter`'s bucketing

--- a/Magic Switch/Manager/DialbackAddresses.swift
+++ b/Magic Switch/Manager/DialbackAddresses.swift
@@ -1,0 +1,147 @@
+import Foundation
+import Network
+
+/// The addresses a peer can dial this Mac back at, for the UI spots where
+/// the user must carry them to the other Mac (the Add by Address sheet and
+/// the not-advertising advisory). Two tiers: the local address an
+/// authenticated connection actually ran over (proven — the peer dialed it,
+/// or will see it as our source), else the addresses of the viable
+/// Wi-Fi/Ethernet interfaces. Which network the peer sits on is unknowable
+/// at bootstrap, so candidates are listed with labels rather than guessed
+/// down to one.
+final class DialbackAddresses: ObservableObject {
+  static let shared = DialbackAddresses()
+
+  /// Local endpoint host of the most recent authenticated connection.
+  /// Main-only (`noteProven` hops).
+  @Published private(set) var provenHost: String?
+  @Published private var currentPath: NWPath?
+
+  private let monitor = NWPathMonitor()
+
+  private init() {
+    monitor.pathUpdateHandler = { [weak self] path in
+      DispatchQueue.main.async { self?.currentPath = path }
+    }
+    monitor.start(queue: DispatchQueue(label: "com.magicswitch.dialback"))
+  }
+
+  /// Record the local endpoint of a connection whose handshake completed.
+  /// Loopback and link-local are refused: a self-dial's handshake succeeds
+  /// against our own listener, and a link-local address is only routable
+  /// with the *dialer's* zone id, which we can't know.
+  func noteProven(endpoint: NWEndpoint?) {
+    guard let host = Self.hostString(from: endpoint), Self.isDialable(host) else { return }
+    DispatchQueue.main.async {
+      if self.provenHost != host { self.provenHost = host }
+    }
+  }
+
+  /// One line for UI captions — "192.168.1.23 (Wi-Fi)", possibly
+  /// "… or 10.0.0.5 (Ethernet)". The proven address wins outright while it
+  /// is still assigned to an interface; otherwise up to two labeled
+  /// candidates in the system's own preference order. nil when nothing
+  /// credible is known. Main-only.
+  func displayList() -> String? {
+    let addresses = Self.interfaceAddresses()
+    let viable = currentPath?.availableInterfaces ?? []
+    let labels = Dictionary(
+      viable.compactMap { iface in Self.label(for: iface.type).map { (iface.name, $0) } },
+      uniquingKeysWith: { first, _ in first })
+    if let proven = provenHost,
+      let owner = addresses.first(where: { $0.host == proven })?.interface
+    {
+      return Self.entry(proven, labels[owner])
+    }
+    // `availableInterfaces` repeats an interface (once per address family).
+    var seenNames: Set<String> = []
+    var entries = viable.compactMap { iface -> String? in
+      guard seenNames.insert(iface.name).inserted,
+        let label = labels[iface.name],
+        let address = addresses.first(where: { $0.interface == iface.name && $0.isIPv4 })
+          ?? addresses.first(where: { $0.interface == iface.name })
+      else { return nil }
+      return Self.entry(address.host, label)
+    }
+    if entries.isEmpty {
+      entries = addresses.filter { $0.isIPv4 }.map { Self.entry($0.host, nil) }
+    }
+    guard !entries.isEmpty else { return nil }
+    return entries.prefix(2).joined(separator: " or ")
+  }
+
+  /// Dialable host string of an endpoint — unlike `RateLimiter`'s bucketing
+  /// it keeps IPv6 zone ids (a stripped link-local address isn't routable)
+  /// but still collapses IPv4-mapped IPv6.
+  static func hostString(from endpoint: NWEndpoint?) -> String? {
+    guard case .hostPort(let host, _) = endpoint else { return nil }
+    switch host {
+    case .ipv4(let addr):
+      return addr.debugDescription
+    case .ipv6(let addr):
+      let raw = addr.debugDescription
+      if raw.lowercased().hasPrefix("::ffff:") {
+        let v4 = String(raw.dropFirst("::ffff:".count))
+        if v4.split(separator: ".").count == 4 { return v4 }
+      }
+      return raw
+    case .name(let name, _):
+      return name
+    @unknown default:
+      return nil
+    }
+  }
+
+  private static func entry(_ host: String, _ label: String?) -> String {
+    label.map { "\(host) (\($0))" } ?? host
+  }
+
+  private static func label(for type: NWInterface.InterfaceType) -> String? {
+    switch type {
+    case .wifi: return "Wi-Fi"
+    case .wiredEthernet: return "Ethernet"
+    default: return nil
+    }
+  }
+
+  private static func isDialable(_ host: String) -> Bool {
+    let lower = host.lowercased()
+    return lower != "::1" && !lower.hasPrefix("127.") && !lower.hasPrefix("fe80:")
+      && !lower.hasPrefix("169.254.")
+  }
+
+  /// Addresses of the up, non-loopback, non-point-to-point interfaces —
+  /// the point-to-point flag is what keeps VPN tunnels out, whose
+  /// addresses the peer usually can't reach.
+  private static func interfaceAddresses() -> [(interface: String, host: String, isIPv4: Bool)] {
+    var result: [(interface: String, host: String, isIPv4: Bool)] = []
+    var ifaddrPtr: UnsafeMutablePointer<ifaddrs>?
+    guard getifaddrs(&ifaddrPtr) == 0 else { return result }
+    defer { freeifaddrs(ifaddrPtr) }
+    var cursor = ifaddrPtr
+    while let current = cursor {
+      defer { cursor = current.pointee.ifa_next }
+      let flags = Int32(bitPattern: current.pointee.ifa_flags)
+      guard flags & IFF_UP != 0, flags & (IFF_LOOPBACK | IFF_POINTOPOINT) == 0,
+        let sa = current.pointee.ifa_addr
+      else { continue }
+      let family = sa.pointee.sa_family
+      guard family == sa_family_t(AF_INET) || family == sa_family_t(AF_INET6) else { continue }
+      var hostBuffer = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+      let status = getnameinfo(
+        sa, socklen_t(sa.pointee.sa_len),
+        &hostBuffer, socklen_t(hostBuffer.count),
+        nil, 0, NI_NUMERICHOST)
+      guard status == 0 else { continue }
+      let host = String(cString: hostBuffer)
+      guard Self.isDialable(host) else { continue }
+      result.append(
+        (
+          interface: String(cString: current.pointee.ifa_name),
+          host: host,
+          isIPv4: family == sa_family_t(AF_INET)
+        ))
+    }
+    return result
+  }
+}

--- a/Magic Switch/Manager/DialbackAddresses.swift
+++ b/Magic Switch/Manager/DialbackAddresses.swift
@@ -26,13 +26,17 @@ final class DialbackAddresses: ObservableObject {
     monitor.start(queue: DispatchQueue(label: "com.magicswitch.dialback"))
   }
 
-  /// Record the local endpoint of a connection whose handshake completed.
-  /// Loopback and link-local are refused: a self-dial's handshake succeeds
-  /// against our own listener, and a link-local address is only routable
-  /// with the *dialer's* zone id, which we can't know.
-  func noteProven(endpoint: NWEndpoint?) {
-    guard let host = Self.hostString(from: endpoint), Self.isDialable(host) else { return }
+  /// Record the local endpoint of a connection whose handshake completed —
+  /// unless the *remote* end is this Mac itself: a self-dial handshakes
+  /// fine (same key, both roles) but proves nothing about how a peer
+  /// reaches us. Loopback and link-local are refused for the same reason a
+  /// link-local address is undialable without the dialer's own zone id.
+  func noteProven(path: NWPath?) {
+    guard let host = Self.hostString(from: path?.localEndpoint), Self.isDialable(host),
+      let remote = Self.hostString(from: path?.remoteEndpoint)
+    else { return }
     DispatchQueue.main.async {
+      guard !Self.interfaceAddresses().contains(where: { $0.host == remote }) else { return }
       if self.provenHost != host { self.provenHost = host }
     }
   }
@@ -65,7 +69,7 @@ final class DialbackAddresses: ObservableObject {
       return Self.entry(address.host, label)
     }
     if entries.isEmpty {
-      entries = addresses.filter { $0.isIPv4 }.map { Self.entry($0.host, nil) }
+      entries = addresses.filter { $0.isIPv4 && !$0.pointToPoint }.map { Self.entry($0.host, nil) }
     }
     guard !entries.isEmpty else { return nil }
     return (entries.prefix(2).joined(separator: " or "), proven: false)
@@ -111,11 +115,15 @@ final class DialbackAddresses: ObservableObject {
       && !lower.hasPrefix("169.254.")
   }
 
-  /// Addresses of the up, non-loopback, non-point-to-point interfaces —
-  /// the point-to-point flag is what keeps VPN tunnels out, whose
-  /// addresses the peer usually can't reach.
-  private static func interfaceAddresses() -> [(interface: String, host: String, isIPv4: Bool)] {
-    var result: [(interface: String, host: String, isIPv4: Bool)] = []
+  /// Addresses of the up, non-loopback interfaces. Point-to-point ones
+  /// (VPN tunnels) are included and flagged: the guess tier excludes them
+  /// (the peer usually can't reach a tunnel address it isn't inside), but
+  /// a *proven* tunnel address — the only route on overlay-network setups —
+  /// must still validate against them.
+  private static func interfaceAddresses()
+    -> [(interface: String, host: String, isIPv4: Bool, pointToPoint: Bool)]
+  {
+    var result: [(interface: String, host: String, isIPv4: Bool, pointToPoint: Bool)] = []
     var ifaddrPtr: UnsafeMutablePointer<ifaddrs>?
     guard getifaddrs(&ifaddrPtr) == 0 else { return result }
     defer { freeifaddrs(ifaddrPtr) }
@@ -123,7 +131,7 @@ final class DialbackAddresses: ObservableObject {
     while let current = cursor {
       defer { cursor = current.pointee.ifa_next }
       let flags = Int32(bitPattern: current.pointee.ifa_flags)
-      guard flags & IFF_UP != 0, flags & (IFF_LOOPBACK | IFF_POINTOPOINT) == 0,
+      guard flags & IFF_UP != 0, flags & IFF_LOOPBACK == 0,
         let sa = current.pointee.ifa_addr
       else { continue }
       let family = sa.pointee.sa_family
@@ -140,7 +148,8 @@ final class DialbackAddresses: ObservableObject {
         (
           interface: String(cString: current.pointee.ifa_name),
           host: host,
-          isIPv4: family == sa_family_t(AF_INET)
+          isIPv4: family == sa_family_t(AF_INET),
+          pointToPoint: flags & IFF_POINTOPOINT != 0
         ))
     }
     return result

--- a/Magic Switch/Manager/IncomingConnection.swift
+++ b/Magic Switch/Manager/IncomingConnection.swift
@@ -55,6 +55,8 @@ final class IncomingConnection {
   private let rateLimiter: RateLimiter
   private let pairingStore: PairingStore
   private let queue: DispatchQueue
+  /// This Mac's identity for INTRODUCE replies. Called on `queue`.
+  private let localIdentity: () -> IntroducedIdentity?
   private let bluetoothStore = BluetoothPeripheralStore.shared
 
   // MARK: - State
@@ -66,6 +68,8 @@ final class IncomingConnection {
   private var selfRef: IncomingConnection?
   private var authenticated = false
   private var finished = false
+  /// Fingerprint of the accept-time PSK snapshot the handshake proved.
+  private var provedFingerprint: String?
 
   // MARK: - Init
 
@@ -74,13 +78,15 @@ final class IncomingConnection {
     endpoint: NWEndpoint?,
     rateLimiter: RateLimiter,
     pairingStore: PairingStore,
-    queue: DispatchQueue
+    queue: DispatchQueue,
+    localIdentity: @escaping () -> IntroducedIdentity?
   ) {
     self.connection = connection
     self.endpoint = endpoint
     self.rateLimiter = rateLimiter
     self.pairingStore = pairingStore
     self.queue = queue
+    self.localIdentity = localIdentity
   }
 
   // MARK: - Lifecycle
@@ -135,6 +141,7 @@ final class IncomingConnection {
         // accept-time PSK snapshot, not the live key, so a re-pair racing
         // this hop can't count a stale proof against the new key.
         let provedFingerprint = PairingStore.fingerprint(forKey: psk)
+        self.provedFingerprint = provedFingerprint
         DispatchQueue.main.async {
           NetworkDeviceStore.shared.resolvePendingFingerprint(
             provedByHandshake: provedFingerprint)
@@ -202,7 +209,8 @@ final class IncomingConnection {
   private func handleCommand(_ command: DeviceCommand) {
     lastReceivedCommand = command
     switch command {
-    case .notification, .syncPeripherals, .unregisterOne, .connectOne, .holdsOne, .adoptReleased:
+    case .notification, .syncPeripherals, .unregisterOne, .connectOne, .holdsOne, .adoptReleased,
+      .introduce:
       // Two-frame commands; data frame handled in `handleCommandData`.
       break
     case .connectAll:
@@ -387,6 +395,26 @@ final class IncomingConnection {
       // Acked on receipt: the goal ("you now own these") is recorded even if a
       // given peripheral isn't registered here or needs a retry to connect.
       sendString(DeviceCommand.operationSuccess.rawValue)
+    case .introduce:
+      guard let identity = IntroducedIdentity(payload: message) else {
+        print("introduce: malformed identity payload")
+        sendString(DeviceCommand.operationFailed.rawValue)
+        break
+      }
+      // Reply on this queue (sealed sends stay serialized here), then hand
+      // the peer's identity — with its source IP — off to the store.
+      if let local = localIdentity() {
+        sendString(local.encoded)
+      } else {
+        sendString(DeviceCommand.operationFailed.rawValue)
+      }
+      if let host = Self.remoteHost(from: endpoint), let proved = provedFingerprint {
+        DispatchQueue.main.async {
+          NetworkDeviceStore.shared.ingestIntroducedPeer(
+            name: identity.name, host: host, port: Int(identity.port),
+            provedFingerprint: proved)
+        }
+      }
     default:
       break
     }
@@ -399,6 +427,28 @@ final class IncomingConnection {
   private static func isValidMACAddress(_ value: String) -> Bool {
     let pattern = "^([0-9A-Fa-f]{2}-){5}[0-9A-Fa-f]{2}$"
     return value.range(of: pattern, options: .regularExpression) != nil
+  }
+
+  /// Source address of this connection, suitable for dialing back — unlike
+  /// `RateLimiter`'s bucketing it keeps IPv6 zone ids (a stripped link-local
+  /// address isn't routable) but still collapses IPv4-mapped IPv6.
+  private static func remoteHost(from endpoint: NWEndpoint?) -> String? {
+    guard case .hostPort(let host, _) = endpoint else { return nil }
+    switch host {
+    case .ipv4(let addr):
+      return addr.debugDescription
+    case .ipv6(let addr):
+      let raw = addr.debugDescription
+      if raw.lowercased().hasPrefix("::ffff:") {
+        let v4 = String(raw.dropFirst("::ffff:".count))
+        if v4.split(separator: ".").count == 4 { return v4 }
+      }
+      return raw
+    case .name(let name, _):
+      return name
+    @unknown default:
+      return nil
+    }
   }
 
   // MARK: - Sending

--- a/Magic Switch/Manager/IncomingConnection.swift
+++ b/Magic Switch/Manager/IncomingConnection.swift
@@ -142,6 +142,9 @@ final class IncomingConnection {
         // this hop can't count a stale proof against the new key.
         let provedFingerprint = PairingStore.fingerprint(forKey: psk)
         self.provedFingerprint = provedFingerprint
+        // The peer dialed this address, which proves it dialable.
+        DialbackAddresses.shared.noteProven(
+          endpoint: self.connection.currentPath?.localEndpoint)
         DispatchQueue.main.async {
           NetworkDeviceStore.shared.resolvePendingFingerprint(
             provedByHandshake: provedFingerprint)
@@ -408,7 +411,7 @@ final class IncomingConnection {
       } else {
         sendString(DeviceCommand.operationFailed.rawValue)
       }
-      if let host = Self.remoteHost(from: endpoint), let proved = provedFingerprint {
+      if let host = DialbackAddresses.hostString(from: endpoint), let proved = provedFingerprint {
         DispatchQueue.main.async {
           NetworkDeviceStore.shared.ingestIntroducedPeer(
             name: identity.name, host: host, port: Int(identity.port),
@@ -427,28 +430,6 @@ final class IncomingConnection {
   private static func isValidMACAddress(_ value: String) -> Bool {
     let pattern = "^([0-9A-Fa-f]{2}-){5}[0-9A-Fa-f]{2}$"
     return value.range(of: pattern, options: .regularExpression) != nil
-  }
-
-  /// Source address of this connection, suitable for dialing back — unlike
-  /// `RateLimiter`'s bucketing it keeps IPv6 zone ids (a stripped link-local
-  /// address isn't routable) but still collapses IPv4-mapped IPv6.
-  private static func remoteHost(from endpoint: NWEndpoint?) -> String? {
-    guard case .hostPort(let host, _) = endpoint else { return nil }
-    switch host {
-    case .ipv4(let addr):
-      return addr.debugDescription
-    case .ipv6(let addr):
-      let raw = addr.debugDescription
-      if raw.lowercased().hasPrefix("::ffff:") {
-        let v4 = String(raw.dropFirst("::ffff:".count))
-        if v4.split(separator: ".").count == 4 { return v4 }
-      }
-      return raw
-    case .name(let name, _):
-      return name
-    @unknown default:
-      return nil
-    }
   }
 
   // MARK: - Sending

--- a/Magic Switch/Manager/IncomingConnection.swift
+++ b/Magic Switch/Manager/IncomingConnection.swift
@@ -143,8 +143,7 @@ final class IncomingConnection {
         let provedFingerprint = PairingStore.fingerprint(forKey: psk)
         self.provedFingerprint = provedFingerprint
         // The peer dialed this address, which proves it dialable.
-        DialbackAddresses.shared.noteProven(
-          endpoint: self.connection.currentPath?.localEndpoint)
+        DialbackAddresses.shared.noteProven(path: self.connection.currentPath)
         DispatchQueue.main.async {
           NetworkDeviceStore.shared.resolvePendingFingerprint(
             provedByHandshake: provedFingerprint)

--- a/Magic Switch/Manager/OutgoingConnection.swift
+++ b/Magic Switch/Manager/OutgoingConnection.swift
@@ -126,6 +126,9 @@ final class OutgoingConnection {
   private var finished = false
   private var connectTimer: DispatchSourceTimer?
   private var bodyTimer: DispatchSourceTimer?
+  /// Fingerprint of the PSK snapshot the completed handshake proved.
+  /// Written and read on `queue`.
+  private(set) var provedFingerprint: String?
 
   // MARK: - Init
 
@@ -209,6 +212,7 @@ final class OutgoingConnection {
             // back. Fingerprint the PSK snapshot this channel actually ran
             // with (see `resolvePendingFingerprint`).
             let provedFingerprint = PairingStore.fingerprint(forKey: psk)
+            self.provedFingerprint = provedFingerprint
             DispatchQueue.main.async {
               NetworkDeviceStore.shared.resolvePendingFingerprint(
                 provedByHandshake: provedFingerprint)

--- a/Magic Switch/Manager/OutgoingConnection.swift
+++ b/Magic Switch/Manager/OutgoingConnection.swift
@@ -214,8 +214,7 @@ final class OutgoingConnection {
             let provedFingerprint = PairingStore.fingerprint(forKey: psk)
             self.provedFingerprint = provedFingerprint
             // The peer will see this address as our source and dial it back.
-            DialbackAddresses.shared.noteProven(
-              endpoint: self.connection.currentPath?.localEndpoint)
+            DialbackAddresses.shared.noteProven(path: self.connection.currentPath)
             DispatchQueue.main.async {
               NetworkDeviceStore.shared.resolvePendingFingerprint(
                 provedByHandshake: provedFingerprint)

--- a/Magic Switch/Manager/OutgoingConnection.swift
+++ b/Magic Switch/Manager/OutgoingConnection.swift
@@ -213,6 +213,9 @@ final class OutgoingConnection {
             // with (see `resolvePendingFingerprint`).
             let provedFingerprint = PairingStore.fingerprint(forKey: psk)
             self.provedFingerprint = provedFingerprint
+            // The peer will see this address as our source and dial it back.
+            DialbackAddresses.shared.noteProven(
+              endpoint: self.connection.currentPath?.localEndpoint)
             DispatchQueue.main.async {
               NetworkDeviceStore.shared.resolvePendingFingerprint(
                 provedByHandshake: provedFingerprint)

--- a/Magic Switch/Manager/ServiceBrowser.swift
+++ b/Magic Switch/Manager/ServiceBrowser.swift
@@ -58,6 +58,13 @@ extension ServiceBrowser: NetServiceBrowserDelegate {
   }
 
   func netServiceBrowser(
+    _ browser: NetServiceBrowser, didNotSearch errorDict: [String: NSNumber]
+  ) {
+    print("Failed to search for services: \(errorDict)")
+    AdvertisingDiagnostics.shared.serviceSearchFailed()
+  }
+
+  func netServiceBrowser(
     _ browser: NetServiceBrowser, didRemove service: NetService, moreComing: Bool
   ) {
     print("Service removed: \(service.name)")

--- a/Magic Switch/Manager/ServiceBrowser.swift
+++ b/Magic Switch/Manager/ServiceBrowser.swift
@@ -43,6 +43,12 @@ final class ServiceBrowser: NSObject, ServiceBrowsing {
     stopBrowsing()
     startBrowsing()
   }
+
+  /// Whether the browser currently sees `name` on the air (found and no
+  /// goodbye yet). Main-only, like the delegate callbacks maintaining it.
+  func isCurrentlyBrowsed(_ name: String) -> Bool {
+    services.contains { $0.name == name }
+  }
 }
 
 // MARK: - NetServiceBrowserDelegate

--- a/Magic Switch/Manager/ServiceBrowser.swift
+++ b/Magic Switch/Manager/ServiceBrowser.swift
@@ -57,6 +57,12 @@ extension ServiceBrowser: NetServiceBrowserDelegate {
     service.resolve(withTimeout: timeout)
   }
 
+  func netServiceBrowserWillSearch(_ browser: NetServiceBrowser) {
+    // A search that comes up — including a Refresh restart — retires any
+    // stale "couldn't search" advisory.
+    AdvertisingDiagnostics.shared.serviceSearchStarted()
+  }
+
   func netServiceBrowser(
     _ browser: NetServiceBrowser, didNotSearch errorDict: [String: NSNumber]
   ) {

--- a/Magic Switch/Manager/ServicePublisher.swift
+++ b/Magic Switch/Manager/ServicePublisher.swift
@@ -46,6 +46,8 @@ final class ServicePublisher: NSObject, NetworkNetworkServicePublishable {
 
   func stopPublishing() {
     listener?.cancel()
+    // nil so a pending relisten (see the `.failed` case) can't resurrect it.
+    listener = nil
     netService?.stop()
     netService = nil
   }
@@ -107,9 +109,22 @@ final class ServicePublisher: NSObject, NetworkNetworkServicePublishable {
       }
     case .failed(let error):
       print("Listener error: \(error)")
-      // A busy fixed port fails here at start(), not as an init throw.
-      if usingFixedPort, boundPort == nil {
-        listener?.cancel()
+      listener?.cancel()
+      if boundPort != nil {
+        // Died after ready. Clear the port so INTRODUCE stops asserting a
+        // dead endpoint, then relisten — unless something else replaced this
+        // listener while the delay ran.
+        boundPort = nil
+        // Bind non-optionally: with a nil `listener` (a stopPublishing race)
+        // the identity check would pass vacuously and resurrect it.
+        if let failed = listener {
+          queue.asyncAfter(deadline: .now() + 1) { [weak self] in
+            guard let self = self, self.listener === failed else { return }
+            self.setupListener()
+          }
+        }
+      } else if usingFixedPort {
+        // A busy fixed port fails here at start(), not as an init throw.
         startListener(on: nil)
       }
     case .cancelled:
@@ -154,6 +169,8 @@ final class ServicePublisher: NSObject, NetworkNetworkServicePublishable {
 
   /// Publishes the service with the specified port
   private func publishService(port: Int) {
+    // A relisten republish must withdraw the previous registration first.
+    netService?.stop()
     let service = NetService(
       domain: serviceDomain,
       type: serviceType,

--- a/Magic Switch/Manager/ServicePublisher.swift
+++ b/Magic Switch/Manager/ServicePublisher.swift
@@ -17,6 +17,10 @@ final class ServicePublisher: NSObject, NetworkNetworkServicePublishable {
 
   private let serviceType = "_magicswitch._tcp."
   private let serviceDomain = "local."
+  /// Fixed rather than ephemeral so endpoints learned outside Bonjour
+  /// survive a relaunch. Unassigned, below the ephemeral range; falls back
+  /// to ephemeral if taken (INTRODUCE propagates the actual bound port).
+  static let defaultPort: UInt16 = 41952
 
   // MARK: - Dependencies
 
@@ -29,6 +33,10 @@ final class ServicePublisher: NSObject, NetworkNetworkServicePublishable {
   private var netService: NetService?
   private let queue = DispatchQueue(label: "com.magicswitch.service.publisher")
   private var fingerprintObserver: AnyCancellable?
+  private var usingFixedPort = false
+  /// Queue-confined, like `advertisedName`.
+  private var boundPort: UInt16?
+  private var advertisedName: String?
 
   // MARK: - NetworkNetworkServicePublishable Implementation
 
@@ -46,11 +54,28 @@ final class ServicePublisher: NSObject, NetworkNetworkServicePublishable {
 
   /// Sets up the network listener with appropriate configuration and handlers
   private func setupListener() {
+    startListener(on: Self.defaultPort)
+  }
+
+  /// Starts a listener on `port`, or an ephemeral one when nil.
+  private func startListener(on port: UInt16?) {
+    usingFixedPort = port != nil
+    let parameters = NWParameters.tcp
+    // Without reuse, TIME_WAIT from a previous run blocks the re-bind.
+    parameters.allowLocalEndpointReuse = true
     do {
-      listener = try NWListener(using: .tcp)
+      if let port = port {
+        listener = try NWListener(using: parameters, on: NWEndpoint.Port(integerLiteral: port))
+      } else {
+        listener = try NWListener(using: parameters)
+      }
       configureListener()
     } catch {
-      handleListenerError(error)
+      if port != nil {
+        startListener(on: nil)
+      } else {
+        handleListenerError(error)
+      }
     }
   }
 
@@ -75,10 +100,18 @@ final class ServicePublisher: NSObject, NetworkNetworkServicePublishable {
     case .ready:
       if let port = listener?.port?.rawValue {
         print("Listener ready: Port \(port)")
-        publishService(port: Int(port))
+        boundPort = port
+        // NetService needs a run loop for its delegate callbacks; this
+        // handler's dispatch queue has none.
+        DispatchQueue.main.async { self.publishService(port: Int(port)) }
       }
     case .failed(let error):
       print("Listener error: \(error)")
+      // A busy fixed port fails here at start(), not as an init throw.
+      if usingFixedPort, boundPort == nil {
+        listener?.cancel()
+        startListener(on: nil)
+      }
     case .cancelled:
       print("Listener was cancelled")
     default:
@@ -93,9 +126,25 @@ final class ServicePublisher: NSObject, NetworkNetworkServicePublishable {
       endpoint: connection.endpoint,
       rateLimiter: rateLimiter,
       pairingStore: pairingStore,
-      queue: queue
+      queue: queue,
+      // Already on `queue`; `currentIdentity()`'s sync hop would deadlock.
+      localIdentity: { [weak self] in self?.identityOnQueue() }
     )
     handler.start()
+  }
+
+  /// This Mac's INTRODUCE identity. Thread-safe; nil until the listener is
+  /// ready.
+  func currentIdentity() -> IntroducedIdentity? {
+    queue.sync { identityOnQueue() }
+  }
+
+  private func identityOnQueue() -> IntroducedIdentity? {
+    guard let port = boundPort else { return nil }
+    return IntroducedIdentity(
+      name: advertisedName ?? Host.current().localizedName ?? "Unknown",
+      port: port
+    )
   }
 
   /// Handles errors that occur during listener setup
@@ -144,9 +193,14 @@ final class ServicePublisher: NSObject, NetworkNetworkServicePublishable {
 extension ServicePublisher: NetServiceDelegate {
   func netServiceDidPublish(_ sender: NetService) {
     print("Service published successfully: \(sender.name)")
+    // mDNS renames on collision; INTRODUCE identities must match the air.
+    let name = sender.name
+    queue.async { self.advertisedName = name }
+    AdvertisingDiagnostics.shared.servicePublished(name: name)
   }
 
   func netService(_ sender: NetService, didNotPublish errorDict: [String: NSNumber]) {
     print("Failed to publish service: \(errorDict)")
+    AdvertisingDiagnostics.shared.servicePublishFailed()
   }
 }

--- a/Magic Switch/Manager/ServicePublisher.swift
+++ b/Magic Switch/Manager/ServicePublisher.swift
@@ -41,15 +41,25 @@ final class ServicePublisher: NSObject, NetworkNetworkServicePublishable {
   // MARK: - NetworkNetworkServicePublishable Implementation
 
   func startPublishing() {
-    setupListener()
+    // On `queue`: the listener state machine owns `listener`/`boundPort`/
+    // `advertisedName` there, so start, stop, and the relisten never race.
+    queue.async { self.setupListener() }
   }
 
   func stopPublishing() {
-    listener?.cancel()
-    // nil so a pending relisten (see the `.failed` case) can't resurrect it.
-    listener = nil
-    netService?.stop()
-    netService = nil
+    queue.async {
+      self.listener?.cancel()
+      // nil so a pending relisten (see the `.failed` case) can't resurrect
+      // it — serialized here, so the relisten guard can't race this check.
+      self.listener = nil
+      self.boundPort = nil
+      self.advertisedName = nil
+    }
+    DispatchQueue.main.async {
+      self.fingerprintObserver = nil
+      self.netService?.stop()
+      self.netService = nil
+    }
   }
 
   // MARK: - Private Setup Methods
@@ -115,6 +125,14 @@ final class ServicePublisher: NSObject, NetworkNetworkServicePublishable {
         // dead endpoint, then relisten — unless something else replaced this
         // listener while the delay ran.
         boundPort = nil
+        // Withdraw the advertisement too. Enqueued to main from this serial
+        // queue, so it always lands *after* any still-pending publish hop
+        // from `.ready` — a dead-port ad can't outlive this failure even if
+        // the relisten never succeeds.
+        DispatchQueue.main.async {
+          self.netService?.stop()
+          self.netService = nil
+        }
         // Bind non-optionally: with a nil `listener` (a stopPublishing race)
         // the identity check would pass vacuously and resurrect it.
         if let failed = listener {

--- a/Magic Switch/Model/Store/NetworkDeviceStore.swift
+++ b/Magic Switch/Model/Store/NetworkDeviceStore.swift
@@ -89,9 +89,12 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
   /// pings. Main-only. See `migrateRenamedPeerIfNeeded`.
   private var pendingMigrationProofs: Set<String> = []
 
-  /// Ids that entered `discoveredNetworkDevices` via INTRODUCE. They never
-  /// get a Bonjour goodbye, so `pollReachability` expires unrefreshed ones —
-  /// else a stale entry blocks `renameCandidateID` forever. Main-only.
+  /// Ids whose discovered entry is kept alive only by INTRODUCE exchanges.
+  /// They never get a Bonjour goodbye, so `pollReachability` expires
+  /// unrefreshed ones — else a stale entry blocks `renameCandidateID`
+  /// forever. A Bonjour resolve clears the flag: that entry is back under
+  /// goodbye semantics, and resolves fire once per `didFind`, so the TTL
+  /// would otherwise grey a peer that's still on the air. Main-only.
   private var introducedIDs: Set<String> = []
   private static let introducedDeviceTTL: TimeInterval = 2.5 * reachabilityInterval
 
@@ -218,7 +221,6 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
       print("Refusing INTRODUCE from a peer using this Mac's own name: \(name)")
       return
     }
-    introducedIDs.insert(name)
     let device = NetworkDevice(
       id: name,
       name: name,
@@ -228,6 +230,8 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
       fingerprint: provedFingerprint
     )
     addDiscoveredNetworkDevice(device)
+    // After the add, which treats every update as Bonjour-sourced.
+    introducedIDs.insert(name)
     updateNetworkDevice(device)
     // After the update: if it just parked this record pending exactly the
     // proved key, the proof supersedes the warning in the same tick (the
@@ -463,6 +467,9 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
 
   /// Adds a newly discovered network device
   func addDiscoveredNetworkDevice(_ device: NetworkDevice) {
+    // All callers but `ingestIntroducedPeer` (which re-flags after) are
+    // Bonjour resolves — the entry is back under goodbye semantics.
+    introducedIDs.remove(device.id)
     if let index = discoveredNetworkDevices.firstIndex(where: { $0.id == device.id }) {
       discoveredNetworkDevices[index].update(with: device)
     } else {
@@ -771,7 +778,8 @@ enum ManualAddError: Error {
     case .selfDial:
       return "That address is this Mac."
     case .legacyPeer:
-      return "The other Mac runs an older version of Magic Switch that can't be added by address. Update it first."
+      return
+        "The other Mac runs an older version of Magic Switch that can't be added by address. Update it first."
     case .anotherMacRegistered(let name):
       return "Only one Mac can be connected at a time. Remove \(name) first."
     case .outgoing(let failure):
@@ -831,7 +839,17 @@ struct IntroducedIdentity {
   var encoded: String { "\(port)|\(name)" }
 
   init(name: String, port: UInt16) {
-    self.name = name
+    // Mirror `init?(payload:)`'s rules so `encoded` always round-trips: when
+    // Bonjour never published, the raw computer name is bound by neither the
+    // 63-byte limit nor any character rules, and a peer that rejects the
+    // payload is indistinguishable from a legacy build.
+    var name = name.components(separatedBy: .controlCharacters).joined()
+      .trimmingCharacters(in: .whitespaces)
+    while name.utf8.count > 63 { name.removeLast() }
+    // Truncation can leave interior whitespace trailing, which the receiver
+    // trims — re-trim so both sides hold the identical name.
+    name = name.trimmingCharacters(in: .whitespaces)
+    self.name = name.isEmpty ? "Unknown" : name
     self.port = port
   }
 
@@ -1201,6 +1219,10 @@ extension NetworkDeviceStore {
           if let registered = self.networkDevices.first(where: { $0.id == identity.name }) {
             completion(.success(registered))
           } else if let other = self.networkDevices.first {
+            // `other` may be this same peer under a stale name: the ingest
+            // above already started the rename migration, whose proof ping
+            // outlives this completion. The list self-corrects moments after
+            // this error shows.
             completion(.failure(.anotherMacRegistered(other.name)))
           } else if let discovered = self.discoveredNetworkDevices.first(
             where: { $0.id == identity.name })

--- a/Magic Switch/Model/Store/NetworkDeviceStore.swift
+++ b/Magic Switch/Model/Store/NetworkDeviceStore.swift
@@ -46,10 +46,11 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
   @AppStorage("networkDevices") private var networkDevicesData: Data = Data()
 
   /// Last active-probe result per device id (runtime only, never persisted).
-  /// Combined signal: Bonjour resolve/withdraw write it on each transition, and
-  /// a repeating `.ping` (plus an on-menu-open `.ping`) keep it honest between
-  /// Bonjour events — so a peer that vanished without a Bonjour goodbye flips
-  /// to false within one poll interval instead of waiting out the mDNS TTL.
+  /// Combined signal: Bonjour resolve/withdraw write it on each transition,
+  /// and a repeating secure-channel probe (plus one on menu open) keeps it
+  /// honest between Bonjour events — so a peer that vanished without a
+  /// Bonjour goodbye flips to false within one poll interval instead of
+  /// waiting out the mDNS TTL.
   @Published private(set) var deviceReachability: [String: Bool] = [:]
   private var reachabilityTimer: DispatchSourceTimer?
   private static let reachabilityInterval: TimeInterval = 30
@@ -87,6 +88,12 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
   /// a burst of resolves for the same service doesn't fan out into a burst of
   /// pings. Main-only. See `migrateRenamedPeerIfNeeded`.
   private var pendingMigrationProofs: Set<String> = []
+
+  /// Ids that entered `discoveredNetworkDevices` via INTRODUCE. They never
+  /// get a Bonjour goodbye, so `pollReachability` expires unrefreshed ones —
+  /// else a stale entry blocks `renameCandidateID` forever. Main-only.
+  private var introducedIDs: Set<String> = []
+  private static let introducedDeviceTTL: TimeInterval = 2.5 * reachabilityInterval
 
   /// In-flight Ping/Sync per device id. Set when the user taps Ping/Sync on the
   /// Macs tab and cleared when the op finishes; the view both disables the
@@ -166,7 +173,19 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
     guard !Self.localAddresses().contains(Self.normalizeHost(device.host)) else { return }
     migrateRenamedPeerIfNeeded(for: device)
     if let index = networkDevices.firstIndex(where: { $0.id == device.id }) {
-      let priorFingerprint = networkDevices[index].fingerprint
+      // The poll's INTRODUCE lands here every 30s; don't rewrite AppStorage
+      // and re-render observers when nothing changed.
+      let prior = networkDevices[index]
+      if prior.host == device.host, prior.port == device.port,
+        prior.fingerprint == device.fingerprint, prior.isActive == device.isActive,
+        prior.pendingFingerprint == nil
+      {
+        if deviceReachability[device.id] != device.isActive {
+          deviceReachability[device.id] = device.isActive
+        }
+        return
+      }
+      let priorFingerprint = prior.fingerprint
       networkDevices[index].update(with: device)
       saveNetworkDevices()
       // Fold the Bonjour signal into reachability: a fresh resolve is a good
@@ -185,6 +204,35 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
         )
       }
     }
+  }
+
+  /// A peer proved the pairing key and stated its listen endpoint
+  /// (`INTRODUCE`). Runs through the same pipeline as a Bonjour resolve, so
+  /// TOFU pinning, the self-address guard, and rename migration all apply —
+  /// with a stronger source: the fingerprint was proved by the handshake,
+  /// not read from a cleartext TXT record.
+  func ingestIntroducedPeer(name: String, host: String, port: Int, provedFingerprint: String) {
+    // Without Bonjour's collision rename, a same-named peer would fight this
+    // Mac over one name-keyed entry. Refuse; renaming a Mac is the fix.
+    guard !isLocalName(name) else {
+      print("Refusing INTRODUCE from a peer using this Mac's own name: \(name)")
+      return
+    }
+    introducedIDs.insert(name)
+    let device = NetworkDevice(
+      id: name,
+      name: name,
+      host: host,
+      port: port,
+      isActive: true,
+      fingerprint: provedFingerprint
+    )
+    addDiscoveredNetworkDevice(device)
+    updateNetworkDevice(device)
+    // After the update: if it just parked this record pending exactly the
+    // proved key, the proof supersedes the warning in the same tick (the
+    // handshake-time resolve hooks fired before these frames existed).
+    resolvePendingFingerprint(provedByHandshake: provedFingerprint)
   }
 
   /// A Mac's Bonjour service name follows its computer name, and `id` *is*
@@ -399,6 +447,18 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
   func refreshDiscovery() {
     discoveredNetworkDevices = []
     serviceBrowser.refresh()
+    // Introduced entries only repopulate via an exchange; kick one now.
+    pollReachability()
+  }
+
+  /// The port this Mac accepts peer connections on. Shown in Add by Address
+  /// so the value can be read off this screen when setting up the other Mac.
+  var localListeningPort: UInt16? { servicePublisher.currentIdentity()?.port }
+
+  /// Both names this Mac answers to: its device name and (when mDNS renamed
+  /// a collision) the name actually advertised.
+  private func isLocalName(_ name: String) -> Bool {
+    name == Host.current().localizedName || name == servicePublisher.currentIdentity()?.name
   }
 
   /// Adds a newly discovered network device
@@ -495,17 +555,18 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
   func refreshReachability() { pollReachability() }
 
   private func pollReachability() {
-    // `.ping` rides the secure channel, so it's meaningless unpaired — skip
+    // The probe rides the secure channel, so it's meaningless unpaired — skip
     // (leaving the pessimistic default) rather than spam `.notPaired` failures.
-    // Skip mismatched peers too — a `.ping` against a peer whose key genuinely
+    // Skip mismatched peers too — a probe against a peer whose key genuinely
     // differs would just auth-fail and feed its inbound rate limiter — EXCEPT
-    // when the pending fingerprint is exactly our current key's: then the ping
+    // when the pending fingerprint is exactly our current key's: then the probe
     // authenticates (we hold the very key being advertised), and its handshake
     // is what lets both sides self-heal the stale mismatch a mutual re-pair
     // leaves behind (see `resolvePendingFingerprint(provedByHandshake:)`).
     // Without the exception, two Macs parked symmetrically would never
     // initiate a connection in either direction and the "proves it over the
     // secure channel" resolution could never actually fire.
+    expireStaleIntroducedDevices()
     guard PairingStore.shared.isPaired else { return }
     let currentFingerprint = PairingStore.shared.fingerprint
     for device in networkDevices
@@ -514,17 +575,39 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
     }
   }
 
+  /// Introduced entries get no Bonjour goodbye; expire the ones no exchange
+  /// has refreshed so they don't read as "still on the air" forever.
+  private func expireStaleIntroducedDevices() {
+    let cutoff = Date().addingTimeInterval(-Self.introducedDeviceTTL)
+    for index in discoveredNetworkDevices.indices
+    where introducedIDs.contains(discoveredNetworkDevices[index].id)
+      && discoveredNetworkDevices[index].isActive
+      && discoveredNetworkDevices[index].lastUpdated < cutoff
+    {
+      discoveredNetworkDevices[index].isActive = false
+    }
+  }
+
   /// One reachability probe against `device`: updates `deviceReachability`
   /// (which greys the menu/Device-tab rows) and advances the
   /// `consecutivePollFailures` streak that triggers peer-vanished adoption.
+  /// The probe is an INTRODUCE, so every successful poll also refreshes the
+  /// peer's endpoint on both ends — the app's only routing source when
+  /// Bonjour advertising is unavailable.
   /// `countsTowardRateLimit: false` keeps these fixed-cadence probes from
   /// tripping our own outbound limiter. Factored out of `pollReachability` so a
   /// single device can be re-probed off-cycle — by the fast confirming recheck
   /// below, and by a Bonjour withdraw — without waiting out the 30s interval.
   private func probeReachability(of device: NetworkDevice) {
-    executeCommand(.ping, on: device, countsTowardRateLimit: false) { [weak self] result in
+    executeIntroduce(on: device, countsTowardRateLimit: false) { [weak self] result in
       DispatchQueue.main.async {
         guard let self = self else { return }
+        if case .success(.peer(let identity, let proved)) = result {
+          self.ingestIntroducedPeer(
+            name: identity.name, host: device.host, port: Int(identity.port),
+            provedFingerprint: proved)
+        }
+        // `.legacy` still counts: the handshake completed.
         let reachable: Bool
         if case .success = result { reachable = true } else { reachable = false }
         // Publish only on change — a steady-state poll would otherwise fire
@@ -675,6 +758,28 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
 
 }
 
+/// Failure surface of `addPeerManually`, rendered inline in the Add by
+/// Address sheet.
+enum ManualAddError: Error {
+  case selfDial
+  case legacyPeer
+  case anotherMacRegistered(String)
+  case outgoing(OutgoingFailure)
+
+  var userMessage: String {
+    switch self {
+    case .selfDial:
+      return "That address is this Mac."
+    case .legacyPeer:
+      return "The other Mac runs an older version of Magic Switch that can't be added by address. Update it first."
+    case .anotherMacRegistered(let name):
+      return "Only one Mac can be connected at a time. Remove \(name) first."
+    case .outgoing(let failure):
+      return failure.userMessage
+    }
+  }
+}
+
 /// Represents different types of device commands
 enum DeviceCommand: String, Codable {
   case unregisterAll = "UNREGISTER_ALL"
@@ -709,6 +814,39 @@ enum DeviceCommand: String, Codable {
   /// sleeping peer to be detected gone. Best-effort: the sender has already
   /// released locally, so a dropped push just falls back to reactive adoption.
   case adoptReleased = "ADOPT_RELEASED"
+  /// Two-frame: opcode then the sender's identity (`<listenPort>|<name>`).
+  /// The receiver learns the sender's routing (source IP + stated listen
+  /// port) over the authenticated channel and replies with its *own*
+  /// identity instead of OP_SUCCESS; legacy builds reply OP_FAILED, which
+  /// still proves the handshake. Keeps endpoints fresh without Bonjour.
+  case introduce = "INTRODUCE"
+}
+
+/// Identity carried by `INTRODUCE` frames: `<listenPort>|<name>`, port first
+/// so the name may contain `|`.
+struct IntroducedIdentity {
+  let name: String
+  let port: UInt16
+
+  var encoded: String { "\(port)|\(name)" }
+
+  init(name: String, port: UInt16) {
+    self.name = name
+    self.port = port
+  }
+
+  init?(payload: String) {
+    let parts = payload.split(separator: "|", maxSplits: 1, omittingEmptySubsequences: false)
+    guard parts.count == 2, let port = UInt16(parts[0]), port > 0 else { return nil }
+    let name = String(parts[1]).trimmingCharacters(in: .whitespaces)
+    // 63 bytes is Bonjour's instance-name limit; introduced ids key the same
+    // store entries as advertised ones.
+    guard !name.isEmpty, name.utf8.count <= 63,
+      name.rangeOfCharacter(from: .controlCharacters) == nil
+    else { return nil }
+    self.name = name
+    self.port = port
+  }
 }
 
 // MARK: - Health Check Extension
@@ -953,6 +1091,131 @@ extension NetworkDeviceStore {
     sendTwoFrameCommand(
       .adoptReleased, payload: addresses.joined(separator: ","), to: device,
       countsTowardRateLimit: false, completion: completion)
+  }
+
+  /// The peer's answer to an INTRODUCE: its identity plus the fingerprint of
+  /// the key the channel proved, or `legacy` from a build that predates the
+  /// opcode (it replied OP_FAILED — still a completed handshake).
+  enum IntroduceReply {
+    case peer(IntroducedIdentity, provedFingerprint: String)
+    case legacy
+  }
+
+  /// Exchanges identities with `device` over the secure channel. Doubles as
+  /// the reachability probe: unlike `.ping`, each successful exchange also
+  /// refreshes routing on both ends, with or without Bonjour.
+  func executeIntroduce(
+    on device: NetworkDevice,
+    countsTowardRateLimit: Bool = true,
+    completion: @escaping (Result<IntroduceReply, OutgoingFailure>) -> Void
+  ) {
+    guard PairingStore.shared.isPaired else {
+      completion(.failure(.notPaired))
+      return
+    }
+    guard let local = servicePublisher.currentIdentity() else {
+      completion(.failure(.connectionFailed("listener not ready")))
+      return
+    }
+    let outgoing = OutgoingConnection(
+      host: device.host, port: UInt16(device.port),
+      countsTowardRateLimit: countsTowardRateLimit)
+    var reply: IntroduceReply?
+    outgoing.run(
+      body: { channel, done in
+        channel.send(Data(DeviceCommand.introduce.rawValue.utf8)) { err in
+          if let err = err {
+            print("INTRODUCE command send failed: \(err)")
+            done(false)
+            return
+          }
+          channel.send(Data(local.encoded.utf8)) { err2 in
+            if let err2 = err2 {
+              print("INTRODUCE payload send failed: \(err2)")
+              done(false)
+              return
+            }
+            channel.receive { result in
+              switch result {
+              case .failure(let err):
+                print("INTRODUCE reply receive failed: \(err)")
+                done(false)
+              case .success(let data):
+                let response = String(data: data, encoding: .utf8) ?? ""
+                if let identity = IntroducedIdentity(payload: response),
+                  let proved = outgoing.provedFingerprint
+                {
+                  reply = .peer(identity, provedFingerprint: proved)
+                  done(true)
+                } else if DeviceCommand(rawValue: response) == .operationFailed {
+                  reply = .legacy
+                  done(true)
+                } else {
+                  done(false)
+                }
+              }
+            }
+          }
+        }
+      },
+      completion: { result in
+        switch result {
+        case .success:
+          completion(reply.map { .success($0) } ?? .failure(.bodyFailed))
+        case .failure(let err):
+          completion(.failure(err))
+        }
+      }
+    )
+  }
+
+  /// Registers a peer from just a dialable endpoint — the bootstrap for
+  /// networks where Bonjour can't carry advertisements in either direction.
+  /// The INTRODUCE reply supplies the name, and the exchange lands this Mac
+  /// in the peer's discovered list, so only one side ever needs to do this.
+  func addPeerManually(
+    host: String, port: UInt16,
+    completion: @escaping (Result<NetworkDevice, ManualAddError>) -> Void
+  ) {
+    let target = NetworkDevice(id: host, name: host, host: host, port: Int(port))
+    executeIntroduce(on: target) { [weak self] result in
+      DispatchQueue.main.async {
+        guard let self = self else { return }
+        switch result {
+        case .failure(let failure):
+          completion(.failure(.outgoing(failure)))
+        case .success(.legacy):
+          completion(.failure(.legacyPeer))
+        case .success(.peer(let identity, let proved)):
+          // The handshake happily completes against our own listener (same
+          // key, both roles), and `registerNetworkDevice` has no self-guard.
+          guard !self.isLocalName(identity.name),
+            !Self.localAddresses().contains(Self.normalizeHost(host))
+          else {
+            completion(.failure(.selfDial))
+            return
+          }
+          self.ingestIntroducedPeer(
+            name: identity.name, host: host, port: Int(identity.port),
+            provedFingerprint: proved)
+          if let registered = self.networkDevices.first(where: { $0.id == identity.name }) {
+            completion(.success(registered))
+          } else if let other = self.networkDevices.first {
+            completion(.failure(.anotherMacRegistered(other.name)))
+          } else if let discovered = self.discoveredNetworkDevices.first(
+            where: { $0.id == identity.name })
+          {
+            self.registerNetworkDevice(device: discovered)
+            self.deviceReachability[identity.name] = true
+            self.consecutivePollFailures[identity.name] = 0
+            self.resolvePendingFingerprint(provedByHandshake: proved)
+            completion(.success(discovered))
+          } else {
+            completion(.failure(.outgoing(.bodyFailed)))
+          }
+        }
+      }
+    }
   }
 
   /// Shared helper for "opcode + single payload frame, await OP_SUCCESS".

--- a/Magic Switch/Model/Store/NetworkDeviceStore.swift
+++ b/Magic Switch/Model/Store/NetworkDeviceStore.swift
@@ -89,13 +89,12 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
   /// pings. Main-only. See `migrateRenamedPeerIfNeeded`.
   private var pendingMigrationProofs: Set<String> = []
 
-  /// Ids whose discovered entry is kept alive only by INTRODUCE exchanges.
-  /// They never get a Bonjour goodbye, so `pollReachability` expires
-  /// unrefreshed ones — else a stale entry blocks `renameCandidateID`
-  /// forever. A Bonjour resolve clears the flag: that entry is back under
-  /// goodbye semantics, and resolves fire once per `didFind`, so the TTL
-  /// would otherwise grey a peer that's still on the air. Main-only.
-  private var introducedIDs: Set<String> = []
+  /// TTL for discovered entries with no live Bonjour presence (INTRODUCE-
+  /// sourced ones): they never get a Bonjour goodbye, so unrefreshed ones
+  /// must expire — else a stale entry blocks `renameCandidateID` forever.
+  /// Entries the browser still sees on the air are exempt; a Bonjour
+  /// resolve fires once per `didFind`, so a quiet-but-advertising peer
+  /// would otherwise decay.
   private static let introducedDeviceTTL: TimeInterval = 2.5 * reachabilityInterval
 
   /// In-flight Ping/Sync per device id. Set when the user taps Ping/Sync on the
@@ -230,8 +229,6 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
       fingerprint: provedFingerprint
     )
     addDiscoveredNetworkDevice(device)
-    // After the add, which treats every update as Bonjour-sourced.
-    introducedIDs.insert(name)
     updateNetworkDevice(device)
     // After the update: if it just parked this record pending exactly the
     // proved key, the proof supersedes the warning in the same tick (the
@@ -467,9 +464,6 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
 
   /// Adds a newly discovered network device
   func addDiscoveredNetworkDevice(_ device: NetworkDevice) {
-    // All callers but `ingestIntroducedPeer` (which re-flags after) are
-    // Bonjour resolves — the entry is back under goodbye semantics.
-    introducedIDs.remove(device.id)
     if let index = discoveredNetworkDevices.firstIndex(where: { $0.id == device.id }) {
       discoveredNetworkDevices[index].update(with: device)
     } else {
@@ -582,14 +576,16 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
     }
   }
 
-  /// Introduced entries get no Bonjour goodbye; expire the ones no exchange
-  /// has refreshed so they don't read as "still on the air" forever.
+  /// Entries with no live Bonjour presence get no goodbye; expire the ones
+  /// no exchange has refreshed so they don't read as "still on the air"
+  /// forever. The browser's view is the exemption ground truth — an entry
+  /// it still sees advertised dies by goodbye, not by TTL.
   private func expireStaleIntroducedDevices() {
     let cutoff = Date().addingTimeInterval(-Self.introducedDeviceTTL)
     for index in discoveredNetworkDevices.indices
-    where introducedIDs.contains(discoveredNetworkDevices[index].id)
-      && discoveredNetworkDevices[index].isActive
+    where discoveredNetworkDevices[index].isActive
       && discoveredNetworkDevices[index].lastUpdated < cutoff
+      && !serviceBrowser.isCurrentlyBrowsed(discoveredNetworkDevices[index].id)
     {
       discoveredNetworkDevices[index].isActive = false
     }
@@ -644,8 +640,40 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
             // long-dark peer doesn't re-arm the watcher every poll forever;
             // a recovery resets the streak and re-arms it for the next one.
             BluetoothPeripheralStore.shared.armAdoptionOfUnheldPeripherals()
+            if device.port != Int(ServicePublisher.defaultPort) {
+              self.probeDefaultPortFallback(of: device)
+            }
           }
         }
+      }
+    }
+  }
+
+  /// A peer that fell back to an ephemeral port (its fixed port was taken
+  /// at launch) binds 41952 again after a relaunch — and with Bonjour
+  /// blocked, nothing else ever re-learns the move, stranding the
+  /// registered record on the dead ephemeral port. Once per confirmed
+  /// outage, try the fixed port; a success re-ingests the fresh endpoint
+  /// through the normal pipeline.
+  private func probeDefaultPortFallback(of device: NetworkDevice) {
+    let candidate = NetworkDevice(
+      id: device.id,
+      name: device.name,
+      host: device.host,
+      port: Int(ServicePublisher.defaultPort),
+      isActive: true,
+      fingerprint: device.fingerprint
+    )
+    executeIntroduce(on: candidate, countsTowardRateLimit: false) { [weak self] result in
+      DispatchQueue.main.async {
+        guard let self = self,
+          case .success(.peer(let identity, let proved)) = result
+        else { return }
+        self.ingestIntroducedPeer(
+          name: identity.name, host: device.host, port: Int(identity.port),
+          provedFingerprint: proved)
+        self.deviceReachability[device.id] = true
+        self.consecutivePollFailures[device.id] = 0
       }
     }
   }
@@ -1224,16 +1252,23 @@ extension NetworkDeviceStore {
             // outlives this completion. The list self-corrects moments after
             // this error shows.
             completion(.failure(.anotherMacRegistered(other.name)))
-          } else if let discovered = self.discoveredNetworkDevices.first(
-            where: { $0.id == identity.name })
-          {
-            self.registerNetworkDevice(device: discovered)
+          } else {
+            // Register from the exchange itself, not the merged discovered
+            // entry — a parked entry from an earlier pairing would smuggle
+            // in its stale host while this very connection just proved the
+            // typed one.
+            let proven = NetworkDevice(
+              id: identity.name,
+              name: identity.name,
+              host: host,
+              port: Int(identity.port),
+              isActive: true,
+              fingerprint: proved
+            )
+            self.registerNetworkDevice(device: proven)
             self.deviceReachability[identity.name] = true
             self.consecutivePollFailures[identity.name] = 0
-            self.resolvePendingFingerprint(provedByHandshake: proved)
-            completion(.success(discovered))
-          } else {
-            completion(.failure(.outgoing(.bodyFailed)))
+            completion(.success(proven))
           }
         }
       }

--- a/Magic Switch/View/Settings/NetworkDeviceManagementView.swift
+++ b/Magic Switch/View/Settings/NetworkDeviceManagementView.swift
@@ -31,6 +31,7 @@ struct NetworkDeviceManagementView: View {
   @ObservedObject private var networkStore = NetworkDeviceStore.shared
   @ObservedObject private var pairing = PairingStore.shared
   @ObservedObject private var diagnostics = AdvertisingDiagnostics.shared
+  @ObservedObject private var dialback = DialbackAddresses.shared
 
   // MARK: - State
 
@@ -81,16 +82,19 @@ struct NetworkDeviceManagementView: View {
         }
       }
 
-      let advisories = [diagnostics.publishWarning, diagnostics.searchWarning].compactMap { $0 }
-      if !advisories.isEmpty {
+      if diagnostics.publishWarning != nil || diagnostics.searchWarning != nil {
         Section {
           // Advisory, not an error: INTRODUCE keeps an added Mac working
           // without Bonjour, so secondary rather than warning colours.
-          ForEach(advisories, id: \.self) { advisory in
-            Label(advisory, systemImage: "info.circle")
-              .font(.callout)
-              .foregroundColor(.secondary)
-              .fixedSize(horizontal: false, vertical: true)
+          // Only the publish advisory gets the dial-back values — it's the
+          // one telling the user to type them on the other Mac; the search
+          // advisory would need the *other* Mac's address, which is
+          // unknowable here.
+          if let warning = diagnostics.publishWarning {
+            advisory(warning + dialbackHint)
+          }
+          if let warning = diagnostics.searchWarning {
+            advisory(warning)
           }
         }
       }
@@ -141,6 +145,22 @@ struct NetworkDeviceManagementView: View {
         )
       }
     }
+  }
+
+  /// Concrete values for the publish advisory's "use Add by Address on the
+  /// other Mac" — with them in hand, the bootstrap needs no other screen.
+  private var dialbackHint: String {
+    guard let addresses = dialback.displayList(),
+      let port = networkStore.localListeningPort
+    else { return "" }
+    return " Enter \(addresses), port \(String(port)) there."
+  }
+
+  private func advisory(_ text: String) -> some View {
+    Label(text, systemImage: "info.circle")
+      .font(.callout)
+      .foregroundColor(.secondary)
+      .fixedSize(horizontal: false, vertical: true)
   }
 
   /// Show both fingerprints so the "verify this was intentional" step can
@@ -340,6 +360,7 @@ private struct AvailableDevicesSectionView: View {
 private struct AddByAddressSheet: View {
   @Binding var isPresented: Bool
   @ObservedObject private var networkStore = NetworkDeviceStore.shared
+  @ObservedObject private var dialback = DialbackAddresses.shared
 
   @State private var host = ""
   @State private var port = String(ServicePublisher.defaultPort)
@@ -370,9 +391,17 @@ private struct AddByAddressSheet: View {
       .disabled(inProgress)
 
       if let localPort = networkStore.localListeningPort {
-        Text("This Mac accepts connections on port \(String(localPort)).")
-          .font(.caption)
-          .foregroundColor(.secondary)
+        // The reverse-direction values, phrased as an instruction for the
+        // other machine so nobody types this Mac's own address into the
+        // fields above.
+        Text(
+          dialback.displayList().map {
+            "On your other Mac, add this Mac as \($0), port \(String(localPort))."
+          } ?? "This Mac accepts connections on port \(String(localPort))."
+        )
+        .font(.caption)
+        .foregroundColor(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
       }
 
       if inProgress {

--- a/Magic Switch/View/Settings/NetworkDeviceManagementView.swift
+++ b/Magic Switch/View/Settings/NetworkDeviceManagementView.swift
@@ -91,7 +91,12 @@ struct NetworkDeviceManagementView: View {
           // advisory would need the *other* Mac's address, which is
           // unknowable here.
           if let warning = diagnostics.publishWarning {
-            advisory(warning + dialbackHint)
+            if let display = dialback.display(), let port = networkStore.localListeningPort {
+              advisory(warning + " Enter \(display.addresses), port \(String(port)) there.")
+                .help(display.proven ? Help.dialbackProven : Help.dialbackGuess)
+            } else {
+              advisory(warning)
+            }
           }
           if let warning = diagnostics.searchWarning {
             advisory(warning)
@@ -147,15 +152,6 @@ struct NetworkDeviceManagementView: View {
     }
   }
 
-  /// Concrete values for the publish advisory's "use Add by Address on the
-  /// other Mac" — with them in hand, the bootstrap needs no other screen.
-  private var dialbackHint: String {
-    guard let addresses = dialback.displayList(),
-      let port = networkStore.localListeningPort
-    else { return "" }
-    return " Enter \(addresses), port \(String(port)) there."
-  }
-
   private func advisory(_ text: String) -> some View {
     Label(text, systemImage: "info.circle")
       .font(.callout)
@@ -192,6 +188,10 @@ struct NetworkDeviceManagementView: View {
     static let refresh = "Re-scan the network for other Macs running Magic Switch."
     static let addByAddress =
       "Add your other Mac by IP address — for networks that block Bonjour discovery."
+    static let dialbackProven =
+      "Confirmed: the most recent secure connection between the two Macs used this address."
+    static let dialbackGuess =
+      "Best guess from this Mac's active network interfaces. If the other Mac can't connect, check this Mac's address in System Settings → Network."
     static let trust =
       "Pin the new pairing key. Only do this if you intentionally re-paired the other Mac."
     static let needsPairing = "Pair this Mac in the Pairing tab first."
@@ -394,11 +394,20 @@ private struct AddByAddressSheet: View {
         // The reverse-direction values, phrased as an instruction for the
         // other machine so nobody types this Mac's own address into the
         // fields above.
-        Text(
-          dialback.displayList().map {
-            "On your other Mac, add this Mac as \($0), port \(String(localPort))."
-          } ?? "This Mac accepts connections on port \(String(localPort))."
-        )
+        Group {
+          if let display = dialback.display() {
+            Text(
+              "On your other Mac, add this Mac as \(display.addresses), port \(String(localPort))."
+            )
+            .help(
+              display.proven
+                ? NetworkDeviceManagementView.Help.dialbackProven
+                : NetworkDeviceManagementView.Help.dialbackGuess
+            )
+          } else {
+            Text("This Mac accepts connections on port \(String(localPort)).")
+          }
+        }
         .font(.caption)
         .foregroundColor(.secondary)
         .fixedSize(horizontal: false, vertical: true)
@@ -419,9 +428,11 @@ private struct AddByAddressSheet: View {
         Spacer()
         Button("Cancel") { isPresented = false }
           .keyboardShortcut(.cancelAction)
+          .help("Close without adding.")
         Button("Add") { submit() }
           .keyboardShortcut(.defaultAction)
           .disabled(!canSubmit)
+          .help("Connect to this address and add the Mac that answers.")
       }
     }
     .padding(20)

--- a/Magic Switch/View/Settings/NetworkDeviceManagementView.swift
+++ b/Magic Switch/View/Settings/NetworkDeviceManagementView.swift
@@ -16,7 +16,7 @@ private enum Constants {
     static let noConnectedDevicesHint =
       "Add your other Mac from \"Macs Found on the Network\" below to start switching peripherals between them."
     static let noAvailableDevicesHint =
-      "Make sure Magic Switch is running on your other Mac and both Macs are on the same Wi-Fi network. Then tap Refresh."
+      "Make sure Magic Switch is running on your other Mac and both Macs are on the same Wi-Fi network. Then tap Refresh — or use the + button to add the Mac by IP address if your network blocks Bonjour."
     static let connectionLimitMessage =
       "Only one Mac can be connected at a time. Remove the existing one first."
     static let notify = "Ping"
@@ -30,6 +30,7 @@ struct NetworkDeviceManagementView: View {
 
   @ObservedObject private var networkStore = NetworkDeviceStore.shared
   @ObservedObject private var pairing = PairingStore.shared
+  @ObservedObject private var diagnostics = AdvertisingDiagnostics.shared
 
   // MARK: - State
 
@@ -77,6 +78,17 @@ struct NetworkDeviceManagementView: View {
           )
           .font(.callout.bold())
           .foregroundColor(.accentColor)
+        }
+      }
+
+      if let warning = diagnostics.warning {
+        Section {
+          // Advisory, not an error: INTRODUCE keeps an added Mac working
+          // without Bonjour, so secondary rather than warning colours.
+          Label(warning, systemImage: "info.circle")
+            .font(.callout)
+            .foregroundColor(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
         }
       }
 
@@ -155,6 +167,8 @@ struct NetworkDeviceManagementView: View {
     static let sync = "Send your peripheral list to this Mac so it knows about them."
     static let remove = "Remove this Mac from the registered list."
     static let refresh = "Re-scan the network for other Macs running Magic Switch."
+    static let addByAddress =
+      "Add your other Mac by IP address — for networks that block Bonjour discovery."
     static let trust =
       "Pin the new pairing key. Only do this if you intentionally re-paired the other Mac."
     static let needsPairing = "Pair this Mac in the Pairing tab first."
@@ -264,11 +278,14 @@ private struct AvailableDevicesSectionView: View {
   // MARK: - Dependencies
 
   @ObservedObject private var networkStore = NetworkDeviceStore.shared
+  @ObservedObject private var pairing = PairingStore.shared
 
   // MARK: - Properties
 
   let devices: [NetworkDevice]
   let onDeviceRegister: (NetworkDevice) -> Void
+
+  @State private var showingAddByAddress = false
 
   var body: some View {
     Section {
@@ -292,12 +309,106 @@ private struct AvailableDevicesSectionView: View {
         Text(Constants.Strings.availableDevices)
           .font(.headline)
         Spacer()
+        Button(action: { showingAddByAddress = true }) {
+          Image(systemName: "plus")
+        }
+        .buttonStyle(.borderless)
+        .disabled(!pairing.isPaired)
+        .help(
+          pairing.isPaired
+            ? NetworkDeviceManagementView.Help.addByAddress
+            : NetworkDeviceManagementView.Help.needsPairing
+        )
+        .accessibilityLabel("Add a Mac by address")
+        .sheet(isPresented: $showingAddByAddress) {
+          AddByAddressSheet(isPresented: $showingAddByAddress)
+        }
         Button(action: { networkStore.refreshDiscovery() }) {
           Image(systemName: "arrow.clockwise")
         }
         .buttonStyle(.borderless)
         .help(NetworkDeviceManagementView.Help.refresh)
         .accessibilityLabel("Refresh available devices")
+      }
+    }
+  }
+}
+
+private struct AddByAddressSheet: View {
+  @Binding var isPresented: Bool
+  @ObservedObject private var networkStore = NetworkDeviceStore.shared
+
+  @State private var host = ""
+  @State private var port = String(ServicePublisher.defaultPort)
+  @State private var inProgress = false
+  @State private var errorMessage: String?
+
+  private var canSubmit: Bool {
+    !host.trimmingCharacters(in: .whitespaces).isEmpty && UInt16(port) != nil && !inProgress
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Add a Mac by Address")
+        .font(.headline)
+      Text(
+        "For networks that block Bonjour. Pair both Macs with the same code first, then enter the other Mac's IP address."
+      )
+      .font(.callout)
+      .foregroundColor(.secondary)
+      .fixedSize(horizontal: false, vertical: true)
+
+      HStack {
+        TextField("IP address", text: $host)
+        TextField("Port", text: $port)
+          .frame(width: 64)
+      }
+      .textFieldStyle(RoundedBorderTextFieldStyle())
+      .disabled(inProgress)
+
+      if let localPort = networkStore.localListeningPort {
+        Text("This Mac accepts connections on port \(String(localPort)).")
+          .font(.caption)
+          .foregroundColor(.secondary)
+      }
+
+      if inProgress {
+        Text("Connecting…")
+          .font(.caption)
+          .foregroundColor(.secondary)
+      } else if let errorMessage = errorMessage {
+        Text(errorMessage)
+          .font(.caption)
+          .foregroundColor(.red)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+
+      HStack {
+        Spacer()
+        Button("Cancel") { isPresented = false }
+          .keyboardShortcut(.cancelAction)
+        Button("Add") { submit() }
+          .keyboardShortcut(.defaultAction)
+          .disabled(!canSubmit)
+      }
+    }
+    .padding(20)
+    .frame(width: 360)
+  }
+
+  private func submit() {
+    guard let portValue = UInt16(port) else { return }
+    inProgress = true
+    errorMessage = nil
+    networkStore.addPeerManually(
+      host: host.trimmingCharacters(in: .whitespaces), port: portValue
+    ) { result in
+      inProgress = false
+      switch result {
+      case .success:
+        isPresented = false
+      case .failure(let error):
+        errorMessage = error.userMessage
       }
     }
   }

--- a/Magic Switch/View/Settings/NetworkDeviceManagementView.swift
+++ b/Magic Switch/View/Settings/NetworkDeviceManagementView.swift
@@ -81,14 +81,17 @@ struct NetworkDeviceManagementView: View {
         }
       }
 
-      if let warning = diagnostics.warning {
+      let advisories = [diagnostics.publishWarning, diagnostics.searchWarning].compactMap { $0 }
+      if !advisories.isEmpty {
         Section {
           // Advisory, not an error: INTRODUCE keeps an added Mac working
           // without Bonjour, so secondary rather than warning colours.
-          Label(warning, systemImage: "info.circle")
-            .font(.callout)
-            .foregroundColor(.secondary)
-            .fixedSize(horizontal: false, vertical: true)
+          ForEach(advisories, id: \.self) { advisory in
+            Label(advisory, systemImage: "info.circle")
+              .font(.callout)
+              .foregroundColor(.secondary)
+              .fixedSize(horizontal: false, vertical: true)
+          }
         }
       }
 
@@ -344,7 +347,7 @@ private struct AddByAddressSheet: View {
   @State private var errorMessage: String?
 
   private var canSubmit: Bool {
-    !host.trimmingCharacters(in: .whitespaces).isEmpty && UInt16(port) != nil && !inProgress
+    !host.trimmingCharacters(in: .whitespaces).isEmpty && (UInt16(port) ?? 0) > 0 && !inProgress
   }
 
   var body: some View {
@@ -397,7 +400,7 @@ private struct AddByAddressSheet: View {
   }
 
   private func submit() {
-    guard let portValue = UInt16(port) else { return }
+    guard let portValue = UInt16(port), portValue > 0 else { return }
     inProgress = true
     errorMessage = nil
     networkStore.addPeerManually(

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Tick the Magic devices you want Magic Switch to hand back and forth. Each row's 
 
 Choose the other Mac under **Macs Found on the Network**. It shows up once it's on the same network running Magic Switch; a greyed-out row means it isn't reachable right now.
 
+If your network blocks Bonjour (some MDM-managed Macs can't advertise; some Wi-Fi networks filter multicast), the other Mac may never appear here. Use the **+** button to add it by IP address instead — one side is enough, the other Mac then lists this one automatically. Magic Switch listens on TCP port **41952**; allow it through any firewall between the two Macs.
+
 <p align="center">
   <img src="docs/assets/device-tab.png" alt="Macs tab showing the connected Mac and available Macs" width="600"><br>
   <em>Macs tab — pick the other Mac, sync peripherals to it, and check it's reachable.</em>
@@ -124,7 +126,7 @@ Magic Switch tells you when there's a new version — it never updates itself. A
 
 - Both Macs running Magic Switch, both showing "Paired" in the Pairing tab.
 - Devices powered on; Bluetooth enabled.
-- Same network; not blocked by firewall.
+- Same network; TCP port 41952 not blocked by firewall.
 - Bluetooth and Local Network permissions granted in System Settings → Privacy & Security.
 - A **greyed-out device** — in the Macs tab or the right-click menu — means it isn't reachable on the network right now (the other Mac is asleep, off Wi-Fi, or not running Magic Switch). Ping, Sync, and switching stay disabled until it's back online.
 - **A switch failed and nothing told you.** Failures — a peripheral that won't connect, a Mac that can't be reached, an identity mismatch — are reported via system notifications, because a hotkey, URL-scheme, or automatic switch has no window to show an error in. If macOS notifications are off for Magic Switch, those failures are completely silent; **Settings → Other** shows a **"Notifications are off"** warning when that's the case. Re-enable them under System Settings → Notifications → Magic Switch. (The Pairing and Macs tabs also show their errors inline, so actions taken *there* still report failures either way.)
@@ -152,7 +154,7 @@ This sets `core.hooksPath` to the in-repo `.hooks/` directory, so be aware you'r
 
 ## Architecture
 
-Two Macs discover each other over Bonjour, then exchange short commands over a sealed TCP channel keyed by the shared pairing code.
+Two Macs discover each other over Bonjour, then exchange short commands over a sealed TCP channel keyed by the shared pairing code. Where Bonjour can't carry advertisements, the channel doubles as discovery: every reachability probe is an INTRODUCE exchange that refreshes both sides' endpoints over the authenticated connection, and a Mac can be bootstrapped by IP address from the Macs tab.
 
 ```
                   Bonjour discovery (_magicswitch._tcp. in local.)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Tick the Magic devices you want Magic Switch to hand back and forth. Each row's 
 
 Choose the other Mac under **Macs Found on the Network**. It shows up once it's on the same network running Magic Switch; a greyed-out row means it isn't reachable right now.
 
-If your network blocks Bonjour (some MDM-managed Macs can't advertise; some Wi-Fi networks filter multicast), the other Mac may never appear here. Use the **+** button to add it by IP address instead — one side is enough, the other Mac then lists this one automatically. Magic Switch listens on TCP port **41952**; allow it through any firewall between the two Macs.
+If your network blocks Bonjour (some MDM-managed Macs can't advertise; some Wi-Fi networks filter multicast), the other Mac may never appear here. Use the **+** button to add it by IP address instead — the sheet on each Mac shows the address and port to enter on the other one, and one side is enough: the other Mac then lists this one automatically. Magic Switch listens on TCP port **41952**; allow it through any firewall between the two Macs.
 
 <p align="center">
   <img src="docs/assets/device-tab.png" alt="Macs tab showing the connected Mac and available Macs" width="600"><br>


### PR DESCRIPTION
Closes #91.

A Mac that can't advertise over mDNS (MDM `NoMulticastAdvertisements`, multicast-filtering APs, client isolation) was permanently invisible to its peer: `ServiceBrowser`'s resolve was the sole writer of `host`/`port`, and the listen port was ephemeral. This makes the authenticated channel itself a discovery source, covering the case where **both** Macs have no Bonjour.

## How

- **`INTRODUCE` opcode** — the 30s reachability poll now exchanges identities (`<listenPort>|<name>`) over the secure channel. The receiver pairs the stated port with the connection's source IP and feeds it through the *same* store pipeline as a Bonjour resolve, so the TOFU pin, self-address guard, and rename migration apply unchanged — with a stronger source: the fingerprint is proved by the ChaCha20-Poly1305 handshake, not read from a cleartext TXT record. Each side replies with its own identity, so one successful probe refreshes routing on both ends.
- **Backward compatible** — a legacy peer answers the unknown opcode with `OP_FAILED`, which still proves a completed handshake, so it polls as reachable and everything else is untouched (`PING` preflights unchanged).
- **Fixed listen port 41952** (unassigned, below the ephemeral range) with a one-shot ephemeral fallback in the listener's `.failed` state; `allowLocalEndpointReuse` so TIME_WAIT can't block a relaunch. INTRODUCE carries whichever port is actually bound.
- **Add by Address** — `+` button in "Macs Found on the Network": IP + prefilled port, no name field (the INTRODUCE reply supplies it). Guards self-dial, the one-Mac limit, legacy peers, unpaired state. One Mac does this once; the exchange lands it in the peer's discovered list for a normal Add.
- **Diagnostics** — `didNotPublish`/`didNotSearch` surface as an advisory Macs-tab banner; a `DNSServiceBrowse` self-check detects the own instance never leaving `kDNSServiceInterfaceIndexLocalOnly`; best-effort CFPreferences read names `NoMulticastAdvertisements` when readable. NetService publishing moved to main so its delegate callbacks actually fire.

## Notes

- Introduce-sourced discovered entries expire after ~75s without a refresh (they get no Bonjour goodbye), keeping `renameCandidateID` honest.
- Identity-mismatch self-heal ordering: the ingest resolves a pending fingerprint *after* the routing update, so a mutual re-pair heals in the same tick.
- Steady-state polls skip the AppStorage rewrite when nothing changed.
- Accepted: peers predating the unknown-opcode ack poll as unreachable; two dark Macs changing IPs simultaneously need one manual re-add.

## Testing

Built clean (`xcodebuild`, zero new warnings); protocol back-compat traced against `handleIncoming` both directions. Needs the two-machine pass on a real `NoMulticastAdvertisements` setup (@bakirgdev offered):

```
# silenced Mac — its own registration stays on interface -1 (LocalOnly)
dns-sd -B _magicswitch._tcp local
# peer — the silenced Mac should appear in Settings → Macs within one poll
# (~30s) of the silenced Mac launching, and switching should work both ways
nc -z <silenced-mac-ip> 41952
```
