### PR TITLE
fix: wake recheck follow-ups for the Bluetooth Off alert

### DIFF
--- a/Magic Switch/AppDelegate/AppDelegate.swift
+++ b/Magic Switch/AppDelegate/AppDelegate.swift
@@ -29,7 +29,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
   /// wakes never post `didWake`, so this stays set across overnight
   /// maintenance wakes.
   private var isSystemSleeping = false
+  /// Radio state captured at `willSleep`, gating the wake recheck.
+  private var bluetoothWasOnBeforeSleep = false
   private var wakeBluetoothRecheck: DispatchWorkItem?
+  private static let bluetoothOffNotificationID = "bluetooth-off"
   /// How long after a real wake to wait before deciding Bluetooth is
   /// genuinely off — the radio takes a moment to power back up.
   private static let bluetoothWakeGrace: TimeInterval = 3
@@ -237,7 +240,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         title: "Bluetooth Unsupported",
         body: "This Mac does not support the Bluetooth features Magic Switch needs."
       )
-    case .poweredOn, .resetting, .unknown:
+    case .poweredOn:
+      // The radio is back; retire a delivered "Bluetooth Off" alert.
+      NotificationManager.removeNotification(identifier: Self.bluetoothOffNotificationID)
+    case .resetting, .unknown:
       break
     @unknown default:
       break
@@ -250,15 +256,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     sleepObserver = center.addObserver(
       forName: NSWorkspace.willSleepNotification, object: nil, queue: .main
     ) { [weak self] _ in
-      self?.isSystemSleeping = true
-      self?.wakeBluetoothRecheck?.cancel()
-      self?.wakeBluetoothRecheck = nil
+      guard let self else { return }
+      self.isSystemSleeping = true
+      self.bluetoothWasOnBeforeSleep = BluetoothManager.shared.state == .poweredOn
+      self.wakeBluetoothRecheck?.cancel()
+      self.wakeBluetoothRecheck = nil
     }
     wakeObserver = center.addObserver(
       forName: NSWorkspace.didWakeNotification, object: nil, queue: .main
     ) { [weak self] _ in
-      self?.isSystemSleeping = false
-      self?.scheduleWakeBluetoothRecheck()
+      guard let self else { return }
+      self.isSystemSleeping = false
+      // Only when sleep began with the radio on: the recheck exists for a
+      // radio that fails to come back, not to re-nag on every wake a user
+      // who keeps Bluetooth off.
+      if self.bluetoothWasOnBeforeSleep {
+        self.scheduleWakeBluetoothRecheck()
+      }
     }
   }
 
@@ -266,6 +280,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
   /// `.poweredOff` during sleep, so no new transition fires and
   /// `handleBluetoothStateChange` stays quiet. Re-check once instead.
   private func scheduleWakeBluetoothRecheck() {
+    wakeBluetoothRecheck?.cancel()
     let work = DispatchWorkItem { [weak self] in
       guard let self, !self.isSystemSleeping else { return }
       self.wakeBluetoothRecheck = nil
@@ -282,7 +297,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     NotificationManager.showNotification(
       title: "Bluetooth Off",
       body: "Magic Switch can't switch peripherals while Bluetooth is off.",
-      identifier: "bluetooth-off"
+      identifier: bluetoothOffNotificationID
     )
   }
 

--- a/Magic Switch/Manager/NotificationManager.swift
+++ b/Magic Switch/Manager/NotificationManager.swift
@@ -65,6 +65,15 @@ final class NotificationManager: NotificationManaging {
     }
   }
 
+  /// Removes a delivered (and any pending) notification posted under
+  /// `identifier` — for stable-identifier alerts whose condition has since
+  /// cleared.
+  static func removeNotification(identifier: String) {
+    let center = UNUserNotificationCenter.current()
+    center.removeDeliveredNotifications(withIdentifiers: [identifier])
+    center.removePendingNotificationRequests(withIdentifiers: [identifier])
+  }
+
   static func showNotification(title: String, body: String, identifier: String? = nil) {
     let content = createNotificationContent(title: title, body: body)
     let request = UNNotificationRequest(


### PR DESCRIPTION
Follow-ups to #90, from a post-merge review of the wake recheck.

## Problems

- **The recheck re-nagged users who keep Bluetooth off on purpose.** Before #90: Bluetooth off before sleep and off after wake produced no new transition, so no alert. After #90: every real wake re-posted the banner (the stable identifier replaces the Notification Center entry, but each post still alerts) — the very nag the original fix set out to end, just moved to wake time.
- **A delivered "Bluetooth Off" alert lingered after the radio recovered** — a radio slower than the 3s grace posts the alert and nothing ever cleared it; same for the ordinary case of a user re-enabling Bluetooth.

## Fix

- Snapshot the radio state at `willSleep` and only schedule the wake recheck when sleep began with Bluetooth **on** — the failed-to-return case the recheck exists for is by definition a was-on case.
- Retire the delivered alert on the `.poweredOn` transition via a new `NotificationManager.removeNotification(identifier:)` (delivered + pending). This also pairs with the 3s grace: if the grace guesses wrong, recovery erases the stale alert.
- Cancel any pending recheck before scheduling a new one, and move the `"bluetooth-off"` identifier to a constant shared by post and removal.

Built clean with xcodebuild; swift-format clean.