### PR TITLE
fix: self-heal one-sided registrations across IP changes

### DIFF
--- a/Magic Switch/Model/Store/NetworkDeviceStore.swift
+++ b/Magic Switch/Model/Store/NetworkDeviceStore.swift
@@ -574,6 +574,41 @@ final class NetworkDeviceStore: ObservableObject, NetworkDeviceManageable {
     where device.pendingFingerprint == nil || device.pendingFingerprint == currentFingerprint {
       probeReachability(of: device)
     }
+    introduceToDiscoveredPeers()
+  }
+
+  /// The one-sided self-heal: polling is driven by *registered* records, so
+  /// a Mac whose user never registered its peer dials nothing — and an IP
+  /// change on this side then never reaches the peer's registered record
+  /// (without Bonjour it points at the old address forever). When nothing is
+  /// registered here, keep the exchange alive from this side by introducing
+  /// to discovered peers that have proved the current pairing key; the
+  /// receiver's source-IP ingest does the healing. Registered setups skip
+  /// this — their poll already exchanges both ways. Same fingerprint gate as
+  /// `migrateRenamedPeerIfNeeded`: an impostor echoing our `fp` over
+  /// cleartext Bonjour earns only a failed handshake.
+  private func introduceToDiscoveredPeers() {
+    guard networkDevices.isEmpty,
+      let currentFingerprint = PairingStore.shared.fingerprint
+    else { return }
+    let localHosts = Self.localAddresses()
+    for device in discoveredNetworkDevices
+    where device.isActive
+      && device.fingerprint == currentFingerprint
+      && device.pendingFingerprint == nil
+      && !localHosts.contains(Self.normalizeHost(device.host))
+    {
+      executeIntroduce(on: device, countsTowardRateLimit: false) { [weak self] result in
+        DispatchQueue.main.async {
+          guard let self = self,
+            case .success(.peer(let identity, let proved)) = result
+          else { return }
+          self.ingestIntroducedPeer(
+            name: identity.name, host: device.host, port: Int(identity.port),
+            provedFingerprint: proved)
+        }
+      }
+    }
   }
 
   /// Entries with no live Bonjour presence get no goodbye; expire the ones


### PR DESCRIPTION
Closes the one-sided gap in #92's endpoint healing.

## Problem

INTRODUCE healing rides the reachability poll, and the poll is driven by *registered* records. A Mac whose user never registered its peer (the half-configured state during setup, or after a one-sided remove) dials nothing — so when **its** IP changes, nothing carries the new address to the peer, and without Bonjour the peer keeps dialing the dead address until a manual re-add.

## Fix

When nothing is registered, `pollReachability` now also introduces to discovered peers that have **proved the current pairing key**, on the same 30s cadence. The receiving side's source-IP ingest heals its registered record exactly as in the mutual case, and the reply refreshes this side's discovered entry so it survives the introduce TTL — the loop is self-sustaining while both Macs are up.

Guards:
- **Registered setups skip it entirely** (`networkDevices.isEmpty` gate) — their poll already exchanges both ways, so no extra traffic in the normal case.
- **Self-addresses are skipped** (Bonjour discovers this Mac's own service; without the filter it would dial itself every 30s).
- **Parked entries are skipped** (no auth-fail spam at a peer whose key genuinely differs).
- **Key-proven only**: same reasoning as the rename-migration gate — an impostor echoing our cleartext `fp` over Bonjour earns nothing but a failed handshake.

## Remaining manual cases (both fundamental)

- Both Macs changing IPs simultaneously with no Bonjour (no rendezvous point exists).
- The half-configured Mac rebooting onto a new address — its discovered list is in-memory, so it has nothing to dial after relaunch.

Built clean with xcodebuild; swift-format clean.