### PR TITLE
fix: eight small fixes from an adversarial bug sweep

### DIFF
--- a/Magic Switch/AppDelegate/AppDelegate.swift
+++ b/Magic Switch/AppDelegate/AppDelegate.swift
@@ -924,6 +924,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
   /// properly key under `.regular` to fire — hence the policy bump +
   /// `makeKeyAndOrderFront(_:)`.
   @objc func openSettingsWindow(_ sender: Any?) {
+    PairingStore.shared.refreshState()
     NSApp.setActivationPolicy(.regular)
     if settingsWindowController == nil {
       settingsWindowController = makeSettingsWindowController()

--- a/Magic Switch/Extensions/NetworkDevice+HealthCheck.swift
+++ b/Magic Switch/Extensions/NetworkDevice+HealthCheck.swift
@@ -39,6 +39,12 @@ extension NetworkDevice: HealthCheckable {
         finish(.success)
       case .failed(let error):
         finish(.failure(error.localizedDescription))
+      case .waiting(let error):
+        // Refused connections park in .waiting without ever failing; report
+        // them now instead of waiting out the 5s timeout.
+        if case .posix(let code) = error, code == .ECONNREFUSED {
+          finish(.failure(error.localizedDescription))
+        }
       default:
         break
       }

--- a/Magic Switch/Manager/AdvertisingDiagnostics.swift
+++ b/Magic Switch/Manager/AdvertisingDiagnostics.swift
@@ -53,6 +53,9 @@ final class AdvertisingDiagnostics: ObservableObject {
 
   private func startSelfCheck(name: String) {
     stopBrowse()
+    // Invalidate the previous check's settle timer before any early return —
+    // it would otherwise report on the state this restart just reset.
+    checkGeneration += 1
     ownName = name
     seenOnWire = false
     var ref: DNSServiceRef?
@@ -69,7 +72,6 @@ final class AdvertisingDiagnostics: ObservableObject {
     guard err == kDNSServiceErr_NoError, let browse = ref else { return }
     DNSServiceSetDispatchQueue(browse, queue)
     browseRef = browse
-    checkGeneration += 1
     let generation = checkGeneration
     queue.asyncAfter(deadline: .now() + Self.settleTime) { [weak self] in
       self?.finishSelfCheck(generation: generation)

--- a/Magic Switch/Manager/HotkeyManager.swift
+++ b/Magic Switch/Manager/HotkeyManager.swift
@@ -69,6 +69,11 @@ final class HotkeyManager: ObservableObject {
   private var hotKeyRefs: [SwitchDirection: EventHotKeyRef] = [:]
   private var eventHandlerRef: EventHandlerRef?
   private var recordingMonitor: Any?
+  /// Ends an abandoned recording when the Settings window closes. The window
+  /// is ordered out rather than torn down (`isReleasedWhenClosed = false`),
+  /// so SwiftUI's `onDisappear` never fires for a close — without this,
+  /// every hotkey would stay unregistered for the rest of the session.
+  private var recordingWindowObserver: NSObjectProtocol?
 
   private init() {}
 
@@ -119,6 +124,12 @@ final class HotkeyManager: ObservableObject {
       self.handleRecordingKeyDown(event)
       return nil  // swallow the event — it was meant for the recorder
     }
+    recordingWindowObserver = NotificationCenter.default.addObserver(
+      forName: NSWindow.willCloseNotification, object: nil, queue: .main
+    ) { [weak self] notification in
+      guard let window = notification.object as? NSWindow, window.level == .normal else { return }
+      self?.cancelRecording()
+    }
   }
 
   func cancelRecording() {
@@ -131,6 +142,10 @@ final class HotkeyManager: ObservableObject {
     if let monitor = recordingMonitor {
       NSEvent.removeMonitor(monitor)
       recordingMonitor = nil
+    }
+    if let observer = recordingWindowObserver {
+      NotificationCenter.default.removeObserver(observer)
+      recordingWindowObserver = nil
     }
     syncRegistration()
   }

--- a/Magic Switch/Manager/OutgoingConnection.swift
+++ b/Magic Switch/Manager/OutgoingConnection.swift
@@ -26,11 +26,13 @@ enum OutgoingFailure: Error {
       return "Couldn't reach the other Mac on the network."
     case .connectTimeout:
       return "The other Mac didn't respond in time."
-    case .handshakeFailed(.authFailed):
+    case .handshakeFailed(.authFailed), .handshakeFailed(.decryptionFailed):
+      // A wrong code fails AEAD-open long before the MAC compare, so
+      // mismatched codes surface as decryptionFailed, not authFailed.
       return "Pairing codes don't match. Re-pair both Macs with the same code."
     case .handshakeFailed(.handshakeTimeout):
       return "The other Mac didn't respond to the secure handshake."
-    case .handshakeFailed(.replay), .handshakeFailed(.decryptionFailed):
+    case .handshakeFailed(.replay):
       return "Couldn't establish a secure connection (possible tampering)."
     case .handshakeFailed:
       return "Couldn't establish a secure connection."
@@ -234,6 +236,16 @@ final class OutgoingConnection {
         self.finish(
           .failure(.connectionFailed(error.localizedDescription)),
           completion: completion)
+      case .waiting(let error):
+        // A refused dial parks in .waiting and never reaches .failed — left
+        // alone it burns the full connect timeout and is reported as a
+        // timeout ("didn't respond") instead of unreachable.
+        if case .posix(let code) = error, code == .ECONNREFUSED {
+          print("OutgoingConnection refused: \(error)")
+          self.finish(
+            .failure(.connectionFailed(error.localizedDescription)),
+            completion: completion)
+        }
       case .cancelled:
         // No-op; finish handled explicitly.
         break

--- a/Magic Switch/Manager/PairingStore.swift
+++ b/Magic Switch/Manager/PairingStore.swift
@@ -36,6 +36,12 @@ final class PairingStore: ObservableObject {
   private static let keychainService = "com.magicswitch.psk-v3"
   private static let keychainAccount = "shared"
 
+  /// Serializes pair/unpair keychain mutations. Without it, a Discard racing
+  /// the ~0.5s in-flight save can interleave delete-then-add and resurrect
+  /// the key the user just threw away.
+  private let mutationQueue = DispatchQueue(
+    label: "com.magicswitch.pairing", qos: .userInitiated)
+
   // MARK: - Published State
 
   @Published private(set) var isPaired: Bool = false
@@ -123,13 +129,13 @@ final class PairingStore: ObservableObject {
 
   /// Derives K from a pairing code and stores it in the keychain.
   /// Runs the PBKDF2 derivation off-main (600k iterations is ~half a second)
-  /// and reports back on main. The published state is updated before the
-  /// completion fires.
+  /// and reports back on main, serialized with `unpair`. The published state
+  /// is updated before the completion fires.
   func pair(
     withCode code: String,
     completion: @escaping (Result<Void, PairingError>) -> Void
   ) {
-    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+    mutationQueue.async { [weak self] in
       guard let self = self else { return }
       let normalized = Self.normalize(code)
       guard Self.isValid(normalized) else {
@@ -166,7 +172,7 @@ final class PairingStore: ObservableObject {
   /// authorize them), so an Unpair that fails would otherwise look like
   /// "nothing happened".
   func unpair(completion: ((OSStatus?) -> Void)? = nil) {
-    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+    mutationQueue.async { [weak self] in
       guard let self = self else { return }
       let query: [String: Any] = [
         kSecClass as String: kSecClassGenericPassword,
@@ -235,7 +241,10 @@ final class PairingStore: ObservableObject {
 
   // MARK: - Private Methods
 
-  private func refreshState() {
+  /// Re-reads the keychain into the published state. Re-run when Settings
+  /// opens: a transient read failure at launch is indistinguishable from
+  /// "unpaired" and would otherwise stick for the whole session.
+  func refreshState() {
     if let data = readKeyData() {
       isPaired = true
       fingerprint = Self.fingerprint(forKey: data)

--- a/Magic Switch/Manager/RateLimiter.swift
+++ b/Magic Switch/Manager/RateLimiter.swift
@@ -63,6 +63,18 @@ final class RateLimiter {
     }
   }
 
+  /// Forget every failure and block, live and persisted. Called when the
+  /// pairing key changes: the history counted handshakes against the old key
+  /// — most commonly the legitimate peer mid-typo — and would otherwise
+  /// outlive the fix by up to 15 minutes.
+  func reset() {
+    queue.sync {
+      failuresByIP.removeAll()
+      blocksByIP.removeAll()
+      UserDefaults.standard.removeObject(forKey: Self.blocksKey)
+    }
+  }
+
   // MARK: - Persistence
 
   private static func loadBlocks() -> [String: CFTimeInterval] {

--- a/Magic Switch/Manager/ServicePublisher.swift
+++ b/Magic Switch/Manager/ServicePublisher.swift
@@ -37,6 +37,19 @@ final class ServicePublisher: NSObject, NetworkNetworkServicePublishable {
   /// Queue-confined, like `advertisedName`.
   private var boundPort: UInt16?
   private var advertisedName: String?
+  /// Clears inbound rate-limit blocks when the pairing key changes — see
+  /// `RateLimiter.reset()`. Lifetime-long, unlike `fingerprintObserver`.
+  private var repairObserver: AnyCancellable?
+
+  // MARK: - Initialization
+
+  override init() {
+    super.init()
+    repairObserver = pairingStore.$fingerprint
+      .removeDuplicates()
+      .dropFirst()
+      .sink { [weak self] _ in self?.rateLimiter.reset() }
+  }
 
   // MARK: - NetworkNetworkServicePublishable Implementation
 

--- a/Magic Switch/Manager/UpdateChecker.swift
+++ b/Magic Switch/Manager/UpdateChecker.swift
@@ -61,7 +61,9 @@ final class UpdateChecker: ObservableObject {
   /// Main-thread only.
   @Published private(set) var isChecking = false
 
-  /// Set when a *manual* check fails to reach GitHub, so the button can say so.
+  /// Set when a *manual* check fails to reach GitHub, so the button can say
+  /// so. Cleared by the next successful check of either kind — a stale
+  /// "Couldn't check" must not outlive a poll that has since succeeded.
   /// Automatic checks stay silent. Main-thread only.
   @Published private(set) var lastCheckFailed = false
 
@@ -171,6 +173,7 @@ final class UpdateChecker: ObservableObject {
           if manual { self.lastCheckFailed = true }
           return
         }
+        self.lastCheckFailed = false
         // Only record success: a transient failure shouldn't suppress the
         // next launch's retry for a full 24h.
         UserDefaults.standard.set(Date(), forKey: Constants.lastCheckedKey)

--- a/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
+++ b/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
@@ -115,10 +115,16 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
   /// `@AppStorage` key for the per-peripheral icon/type overrides map.
   static let typeOverridesDefaultsKey = "peripheralTypeOverrides"
 
+  /// `@AppStorage` key for the last-known Class of Device per address.
+  static let deviceClassesDefaultsKey = "peripheralDeviceClasses"
+
   @AppStorage("peripherals") private var peripheralsData: Data = Data()
 
   @AppStorage(BluetoothPeripheralStore.typeOverridesDefaultsKey)
   private var typeOverridesData: Data = Data()
+
+  @AppStorage(BluetoothPeripheralStore.deviceClassesDefaultsKey)
+  private var deviceClassesData: Data = Data()
 
   /// When set (default), `prepareForSleep` releases held peripherals on
   /// system sleep. Off lets a user keep a peripheral bonded to a Mac that
@@ -150,8 +156,15 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
 
   /// Bluetooth Class of Device per address, captured from the live paired
   /// snapshot. Feeds auto-detection (especially audio gear, whose names rarely
-  /// say "headphones"). Not persisted — refreshed each `fetchConnectedPeripherals`.
-  @Published private(set) var deviceClasses: [String: UInt32] = [:]
+  /// say "headphones"). Persisted, and merged rather than replaced on each
+  /// `fetchConnectedPeripherals`: a handed-off peripheral leaves the local
+  /// paired list, and dropping its class would flip type-based matching (menu
+  /// icons, URL-scheme type selectors) to name-only exactly when a cross-Mac
+  /// `take` needs it. A device's class never changes for a given address, so
+  /// kept entries stay correct.
+  @Published private(set) var deviceClasses: [String: UInt32] = [:] {
+    didSet { saveDeviceClasses() }
+  }
 
   /// Runtime connection state per peripheral id. Driven by pair completion and
   /// IOBluetooth disconnect notifications.
@@ -313,6 +326,7 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
     super.init()
     loadPeripherals()
     loadTypeOverrides()
+    loadDeviceClasses()
     fetchConnectedPeripherals()
     registerForSystemBluetoothConnects()
     setupSleepRelease()
@@ -1258,7 +1272,8 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
           // an unconditional reassign would fire `objectWillChange` every tick
           // (needless re-renders, and it could dismiss an open type picker).
           if self.discoveredPeripherals != paired { self.discoveredPeripherals = paired }
-          if self.deviceClasses != classes { self.deviceClasses = classes }
+          let mergedClasses = self.deviceClasses.merging(classes) { _, live in live }
+          if self.deviceClasses != mergedClasses { self.deviceClasses = mergedClasses }
           if self.batteryLevels != battery { self.batteryLevels = battery }
           // Renaming a device in System Settings → Bluetooth should propagate
           // to our stored list (and thus the dropdown / Settings), so reconcile
@@ -1335,7 +1350,11 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
     }
 
     DispatchQueue.main.async {
-      self.pendingPairs.removeValue(forKey: address)
+      // Only clear our own entry: a stale attempt's late callback must not
+      // free a newer in-flight pair for the same address.
+      if self.pendingPairs[address] === pair {
+        self.pendingPairs.removeValue(forKey: address)
+      }
     }
 
     guard error == kIOReturnSuccess else {
@@ -1988,6 +2007,23 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
         [String: PeripheralType].self, from: typeOverridesData)
     } catch {
       print("Failed to load type overrides: \(error)")
+    }
+  }
+
+  private func saveDeviceClasses() {
+    do {
+      deviceClassesData = try JSONEncoder().encode(deviceClasses)
+    } catch {
+      print("Failed to save device classes: \(error)")
+    }
+  }
+
+  private func loadDeviceClasses() {
+    guard !deviceClassesData.isEmpty else { return }
+    do {
+      deviceClasses = try JSONDecoder().decode([String: UInt32].self, from: deviceClassesData)
+    } catch {
+      print("Failed to load device classes: \(error)")
     }
   }
 

--- a/Magic Switch/View/MenuBar/DropdownContentView.swift
+++ b/Magic Switch/View/MenuBar/DropdownContentView.swift
@@ -51,7 +51,9 @@ final class MenuRowControl: NSControl {
       setHighlighted(inside)
     }
     setHighlighted(false)
-    if inside { onClick() }
+    // The stores can rebuild the menu while the tracking loop runs; a row
+    // replaced mid-press has no window and its action captures stale state.
+    if inside, window != nil { onClick() }
   }
 
   // MARK: - Hover highlight


### PR DESCRIPTION
Findings from a multi-agent review sweep (every finding independently re-traced against the code before fixing). One commit per concern; all are small and standalone.

- **Pairing Discard race**: `pair()`/`unpair()` ran unserialized on the global concurrent queue, so Discard during the ~0.5s PBKDF2 save deleted first and the save then resurrected the discarded code — the Mac stayed paired to a key the user threw away. Now serialized on one queue. Settings-open also re-reads pairing state, healing a transient keychain read failure that otherwise reads as "unpaired" all session.
- **Hotkeys lost after abandoned recording**: recording unregisters all hotkeys; closing Settings mid-recording never fired `onDisappear` (the window is ordered out, not torn down), leaving them unregistered all session. A `willCloseNotification` observer now cancels the recording.
- **Refused dials misreported**: a refused TCP connect parks `NWConnection` in `.waiting` and never reaches `.failed`, so it burned the 5s timeout and reported "didn't respond". Both dialers now fail fast on `ECONNREFUSED`.
- **Wrong code reported as tampering**: a mismatched pairing code fails AEAD-open before the MAC compare, so users saw "possible tampering" while the "codes don't match" message was unreachable. `decryptionFailed` now maps to the codes-don't-match message.
- **Rate-limit blocks outlive a re-pair**: inbound blocks (persisted, 15 min) recorded failures against the old key — typically the legit peer mid-typo — and survived fixing the code. The pairing fingerprint changing now resets the limiter.
- **Type selectors break across handoffs**: `deviceClasses` was rebuilt from the live paired snapshot, so a handed-off peripheral lost its Class of Device and type-based matching (menu icons, `peripheral=<type>` URL selectors) degraded to name-only exactly when a cross-Mac `take` needs it. Now persisted and merged. Plus an identity guard so a stale `devicePairingFinished` can't free a newer in-flight pair.
- **Dropdown stale-row clicks**: a store-driven rebuild during the press-tracking loop detaches the row; its action then fired with stale state. Detached rows now drop the click.
- Two small ones: a successful update check now clears the sticky "Couldn't check" flag, and the advertising self-check bumps its generation before any early return so an aborted restart can't produce a false "not advertising" warning.

Confirmed-but-deferred (need hardware testing, happy to file issues): connect-attempt bookkeeping lacks attempt identity (stale failures can clobber a newer attempt), wake reclaim with auto-reconnect off no-ops against sleep-released devices, and `unregisterFromPC`/`disconnectPeripheral` run blocking IOBluetooth calls on the main thread.

Not built in Xcode here, but `swiftc -typecheck` against the macOS SDK passes — please build before merging.