### PR TITLE
fix: reclaim sleep-released peripherals on wake when auto-reconnect is off

### DIFF
--- a/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
+++ b/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
@@ -455,8 +455,8 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
   /// it's unreachable). On top of the watcher, fires one direct blind pair
   /// per peripheral we unpaired for sleep (`directReclaimAfterWake`) — those
   /// are usually invisible to the watcher's probe until touched, so the probe
-  /// alone tends to miss them. When off, falls back to the original one-shot reclaim
-  /// of just the peripherals we released for sleep. Waits
+  /// alone tends to miss them. When off, runs just that direct reclaim for
+  /// the sleep-released set — no watcher, same silent one-shot. Waits
   /// `Constants.wakeReclaimDelay` first so the network can reassociate (and
   /// bonded devices get a moment to reconnect on their own) before any
   /// unreachable-looking peer gets a peripheral grabbed back.
@@ -498,37 +498,21 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
         return
       }
 
-      // Feature off: original one-shot reclaim, scoped to the peripherals we
-      // released for sleep. The registered peer is not gated on `isActive`
-      // (Bonjour may not have re-resolved yet, but `executeHoldsOne` actually
-      // connects, so reachability is decided there).
+      // Feature off: no watcher to arm — reclaim the sleep-released set with
+      // the same one-shot direct pass the watcher path layers on. These
+      // devices are bonded to no Mac, so the announced, range-gated connect
+      // can't see them: it would just no-op into a spurious "Couldn't
+      // Connect" notification per peripheral on every wake.
       for id in released {
         self.intentionalReleases.removeValue(forKey: id)
-        guard let peripheral = self.peripherals.first(where: { $0.id == id }) else { continue }
-        guard let device = NetworkDeviceStore.shared.networkDevices.first,
-          device.pendingFingerprint == nil,
-          PairingStore.shared.isPaired
-        else {
-          // No trusted peer to ask — none registered, or one flagged as a
-          // TOFU identity mismatch. Either way, reclaim locally.
-          self.connectPeripheral(peripheral)
-          continue
-        }
-        NetworkDeviceStore.shared.executeHoldsOne(address: id, on: device) {
-          [weak self] result in
-          guard let self = self else { return }
-          // `.success` = peer holds it (in use over there) → leave it.
-          // Any `.failure` (peer says no, or unreachable) → take it back.
-          if case .failure = result {
-            self.connectPeripheral(peripheral)
-          }
-        }
       }
+      self.directReclaimAfterWake(released)
     }
   }
 
   /// One-shot direct reclaim of the peripherals we unpaired for sleep, run at
-  /// wake alongside arming the watcher (main queue). Covers the round trip
+  /// wake (main queue) — alongside the watcher when auto-reconnect is on,
+  /// alone when it's off. Covers the round trip
   /// where nothing adopted them while we slept (the other Mac stayed asleep or
   /// off the network): such a peripheral is bonded to no Mac, so it never
   /// reconnects on its own, and it only answers the watcher's RSSI probe in


### PR DESCRIPTION
From the adversarial review sweep (confirmed finding). With auto-reconnect off, the wake reclaim used the announced, range-gated public `connectPeripheral` — but a sleep-released peripheral is bonded to no Mac and invisible to the RSSI probe, so the reclaim deterministically no-op'd into a "Couldn't Connect" notification per peripheral on every wake. The OFF branch now reuses `directReclaimAfterWake`, the same silent blind-pair pass the ON path has used since bf7bc5d (an in-flight pair pages continuously, so a keypress in the first minute gets caught). Also fixes the OFF branch touching main-only state from the connection queue (missing hop in its `HOLDS_ONE` completion).

Trade-off (flagged by review, accepted): the blind pair holds `.connecting` for up to the 60s watchdog instead of failing sub-second, so the full-set switch is disabled during that window post-wake — identical to the existing default-ON behavior.

Test (auto-reconnect OFF, release-on-sleep on, two Macs): close the lid on one Mac, wake it — no "Couldn't Connect" notifications; tap the released keyboard within a minute — it reconnects. Typechecked here; please build before merging.