### PR TITLE
Security hardening: HOLDS_ONE scope, pairing-confirmation, session revocation, pre-auth connection cap

### DIFF
--- a/Magic Switch/Manager/IncomingConnection.swift
+++ b/Magic Switch/Manager/IncomingConnection.swift
@@ -356,16 +356,24 @@ final class IncomingConnection {
         sendString(DeviceCommand.operationFailed.rawValue)
         break
       }
+      let store = bluetoothStore
+      let address = message
       // Read-only query: OP_SUCCESS only if we have a live connection to it,
       // so the peer's wake-time reclaim won't grab a peripheral we're using.
       // The BT check completes on the Bluetooth queue; hop back to the
       // connection queue so all sealed sends stay serialized there (the send
       // counter isn't synchronized across queues).
-      bluetoothStore.isHoldingPeripheral(address: message) { [weak self] held in
+      DispatchQueue.main.async { [weak self] in
         guard let self = self else { return }
-        self.queue.async {
-          self.sendString(
-            (held ? DeviceCommand.operationSuccess : DeviceCommand.operationFailed).rawValue)
+        guard store.peripherals.contains(where: { $0.id == address }) else {
+          self.queue.async { self.sendString(DeviceCommand.operationFailed.rawValue) }
+          return
+        }
+        store.isHoldingPeripheral(address: address) { held in
+          self.queue.async {
+            self.sendString(
+              (held ? DeviceCommand.operationSuccess : DeviceCommand.operationFailed).rawValue)
+          }
         }
       }
     case .adoptReleased:

--- a/Magic Switch/Manager/IncomingConnection.swift
+++ b/Magic Switch/Manager/IncomingConnection.swift
@@ -179,10 +179,20 @@ final class IncomingConnection {
         self.teardown()
       case .success(let data):
         self.resetIdleTimer()
+        guard self.currentlyAuthorized() else {
+          print("Dropping frame: pairing key changed or removed since handshake")
+          self.teardown()
+          return
+        }
         self.handleIncoming(data: data)
         self.readNext()
       }
     }
+  }
+
+  private func currentlyAuthorized() -> Bool {
+    guard let key = pairingStore.currentKey() else { return false }
+    return PairingStore.fingerprint(forKey: key) == provedFingerprint
   }
 
   // MARK: - Command Handling

--- a/Magic Switch/Manager/IncomingConnection.swift
+++ b/Magic Switch/Manager/IncomingConnection.swift
@@ -68,6 +68,7 @@ final class IncomingConnection {
   private var selfRef: IncomingConnection?
   private var authenticated = false
   private var finished = false
+  private var pendingCounted = false
   /// Fingerprint of the accept-time PSK snapshot the handshake proved.
   private var provedFingerprint: String?
 
@@ -108,6 +109,14 @@ final class IncomingConnection {
       return
     }
 
+    guard rateLimiter.beginPending(endpoint: endpoint) else {
+      print("Rejecting connection: too many concurrent unauthenticated handshakes")
+      connection.cancel()
+      release()
+      return
+    }
+    pendingCounted = true
+
     let channel = SecureChannel(
       connection: connection, role: .server, psk: psk, queue: queue
     )
@@ -132,6 +141,7 @@ final class IncomingConnection {
       switch result {
       case .success:
         self.authenticated = true
+        self.endPendingIfNeeded()
         // The peer has proved possession of the pairing key this handshake
         // ran with — strictly stronger evidence than the fingerprint it
         // advertises over cleartext mDNS. If a registered device is stuck
@@ -492,6 +502,7 @@ final class IncomingConnection {
   private func teardown() {
     guard !finished else { return }
     finished = true
+    endPendingIfNeeded()
     idleTimer?.cancel()
     totalTimer?.cancel()
     idleTimer = nil
@@ -499,6 +510,12 @@ final class IncomingConnection {
     channel?.cancel()
     connection.cancel()
     release()
+  }
+
+  private func endPendingIfNeeded() {
+    guard pendingCounted else { return }
+    pendingCounted = false
+    rateLimiter.endPending(endpoint: endpoint)
   }
 
   private func release() {

--- a/Magic Switch/Manager/RateLimiter.swift
+++ b/Magic Switch/Manager/RateLimiter.swift
@@ -17,6 +17,8 @@ final class RateLimiter {
   private static let failureThreshold = 5
   private static let blockDuration: TimeInterval = 15 * 60
   private static let blocksKey = "com.magicswitch.ratelimiter.blocks"
+  private static let maxPendingPerIP = 8
+  private static let maxPendingTotal = 64
 
   // MARK: - State
 
@@ -25,6 +27,9 @@ final class RateLimiter {
   private var failuresByIP: [String: [CFTimeInterval]] = [:]
   /// Monotonic deadline (seconds since boot) at which the block lifts.
   private var blocksByIP: [String: CFTimeInterval] = [:]
+  /// In-flight pre-auth connection counts, per IP and in total.
+  private var pendingByIP: [String: Int] = [:]
+  private var pendingTotal = 0
 
   // MARK: - Init
 
@@ -43,6 +48,30 @@ final class RateLimiter {
         return false
       }
       return true
+    }
+  }
+
+  /// Reserve a pre-auth connection slot; false if the per-IP or global cap is hit.
+  func beginPending(endpoint: NWEndpoint?) -> Bool {
+    let key = Self.bucket(for: endpoint)
+    return queue.sync {
+      guard pendingTotal < Self.maxPendingTotal,
+        pendingByIP[key, default: 0] < Self.maxPendingPerIP
+      else { return false }
+      pendingByIP[key, default: 0] += 1
+      pendingTotal += 1
+      return true
+    }
+  }
+
+  /// Release a slot reserved by `beginPending`.
+  func endPending(endpoint: NWEndpoint?) {
+    let key = Self.bucket(for: endpoint)
+    queue.sync {
+      if let count = pendingByIP[key] {
+        if count <= 1 { pendingByIP.removeValue(forKey: key) } else { pendingByIP[key] = count - 1 }
+      }
+      if pendingTotal > 0 { pendingTotal -= 1 }
     }
   }
 

--- a/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
+++ b/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
@@ -1558,8 +1558,14 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
     else {
       return
     }
-    print("Accepting Bluetooth pairing confirmation for \(address): \(numericValue)")
-    pair.replyUserConfirmation(true)
+    DispatchQueue.main.async { [weak self] in
+      guard let self = self else { return }
+      let initiated = self.pendingPairs[address] === pair
+      print(
+        "Bluetooth pairing confirmation for \(address) (\(numericValue)): "
+          + (initiated ? "accept" : "refuse"))
+      pair.replyUserConfirmation(initiated)
+    }
   }
 
   @objc func devicePairingPINCodeRequest(_ sender: Any!) {


### PR DESCRIPTION
Four independent, behavior-preserving hardening fixes (one commit each). Not build-verified locally (Command Line Tools only, no full Xcode).

**HOLDS_ONE presence oracle (CWE-200).** The handler answered a live-connection query for any syntactically valid MAC, letting an authenticated peer probe arbitrary Bluetooth devices. Now gated on membership in the registered peripheral list, mirroring `.connectOne`/`.unregisterOne`.

**Auto-accepted pairing confirmation (CWE-287).** `devicePairingUserConfirmationRequest` replied `replyUserConfirmation(true)` unconditionally. Now only confirms a pairing this Mac itself initiated (`pendingPairs[address] === pair`); unsolicited requests are refused. Handoff/connect flows still auto-confirm, so automatic switching is unchanged. (Does not fully close the same-address MITM race during an initiated re-pair — that needs a UI decision; see below.)

**Post-revocation command window (CWE-613).** Dispatch only checked the per-connection `authenticated` flag, so a peer authenticated before an unpair/re-pair kept command control until its timers expired (up to 5 min). Each inbound frame now re-checks that the current PSK fingerprint still matches the one the handshake proved, tearing down on mismatch. Steady-state sessions are unaffected.

**Unbounded pre-auth connections (CWE-400).** The listener accepted and retained a handler per socket with no cap, and stalled handshakes record no rate-limiter failure. Added per-IP (8) and global (64) caps on in-flight pre-auth connections, reserved before the handshake and released on auth or teardown. Caps are generous, so the legitimate peer is never refused.

## Deliberately not included (need product/UX decisions, not mechanical fixes)
- **Sync overwriting the peripheral allowlist (CWE-862):** sync is a frequent, automatic, whole-list operation between the two paired Macs, so a safe fix (confirm peer-introduced *new* peripherals) is a UX change, not a patch.
- **User-chosen low-entropy pairing codes / static PBKDF2 salt (CWE-521):** generated codes are safe (60 bits + 600k PBKDF2); a salt change would break cross-version pairing. Needs a decision on whether to forbid custom codes.
- **URL-scheme automation (CWE-306):** inherent to macOS custom URL schemes; only toggles the user's own peripherals between their own paired Macs. Informational.