### PR TITLE
fix: reply to the legacy PIN request instead of letting the pair hang

### DIFF
--- a/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
+++ b/Magic Switch/Model/Store/BluetoothPeripheralStore.swift
@@ -1568,7 +1568,21 @@ final class BluetoothPeripheralStore: NSObject, ObservableObject, BluetoothPerip
     else {
       return
     }
-    print("Bluetooth pairing requested a PIN code for \(address)")
+    DispatchQueue.main.async { [weak self] in
+      guard let self = self else { return }
+      guard self.pendingPairs[address] === pair else {
+        print("Ignoring Bluetooth PIN code request for \(address): not our pairing")
+        return
+      }
+      print("Replying to Bluetooth PIN code request for \(address)")
+      // Legacy HID peripherals with no keypad take the all-zero PIN.
+      var code = BluetoothPINCode()
+      let digits = Array("0000".utf8)
+      withUnsafeMutableBytes(of: &code.data) { raw in
+        for (index, byte) in digits.enumerated() { raw[index] = byte }
+      }
+      pair.replyPINCode(digits.count, pinCode: &code)
+    }
   }
 
   /// Selector target for `IOBluetoothDevice.register(forDisconnectNotification:...)`.


### PR DESCRIPTION
`devicePairingPINCodeRequest` logged the request and returned. The delegate contract requires `replyPINCode` in response ("must be invoked in response and happen before the timeout period of the device"), so any peripheral that falls back to legacy PIN pairing sat at "Pairing…" until the 60s watchdog, every attempt.

Reply with the all-zero PIN legacy HID peripherals use, and only for a pair this app installed in `pendingPairs` — a request belonging to any other pair is left alone rather than answered on its behalf. Same gating and main-hop as the confirmation handler in #107, so the two compose.

Found while looking into #109; independent of it.